### PR TITLE
fix build versions

### DIFF
--- a/buildscripts/set_plist_build.sh
+++ b/buildscripts/set_plist_build.sh
@@ -1,29 +1,19 @@
-#!/bin/bash
+#!/bin/bash -e
 
-buildnum="$(git log -n 1 '--pretty=format:%h')"
+sha="$(git log -n 1 '--pretty=format:%h')"
 if [[ $(git status -s | wc -c) -ne 0 ]]; then 
-  # See Version.swift for how we parse this
-  buildnum="${buildnum}FFFF"
+  sha="${sha}.dirty"
 fi
-buildnum="$((16#$buildnum))"
 
+info_plist="$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH"
 target_plist="$TARGET_BUILD_DIR/$INFOPLIST_PATH"
 dsym_plist="$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME/Contents/Info.plist"
-for plist in "$target_plist" "$dsym_plist"; do
+for plist in "$info_plist" "$target_plist" "$dsym_plist"; do
   if [ -f "$plist" ]; then
-    short_string="$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$plist")"
-    if ! grep -q '^[0-9]\+\.[0-9]\+$' <<< "$short_string" ; then
-      self_without_prefix="${0#"$SRCROOT"}"
-      echo "Error!!"
-      echo "Error!!"
-      echo "Error!! .$self_without_prefix:"
-      echo "Error!! Version number must have exactly two parts ('xx.yy', not 'xx' or 'xx.yy.zz')"
-      echo "Error!! Is: $short_string"
-      echo "Error!!"
-      echo "Error!!"
-      exit 1
-    fi
-    full_string="${short_string}.$buildnum"
-    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $full_string" "$plist"
+    echo "Found plist:  $plist"
+    /usr/libexec/PlistBuddy -c "Delete :ComYuvalShavitWtfdidVersion" "$plist" || true
+    /usr/libexec/PlistBuddy -c "Add :ComYuvalShavitWtfdidVersion string $sha" "$plist"
+  else
+    echo "Missing plist: $plist"
   fi
 done

--- a/buildscripts/set_plist_build.sh
+++ b/buildscripts/set_plist_build.sh
@@ -11,8 +11,14 @@ dsym_plist="$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME/Contents/Info.plist"
 for plist in "$info_plist" "$target_plist" "$dsym_plist"; do
   if [ -f "$plist" ]; then
     echo "Found plist:  $plist"
-    /usr/libexec/PlistBuddy -c "Delete :ComYuvalShavitWtfdidVersion" "$plist" || true
-    /usr/libexec/PlistBuddy -c "Add :ComYuvalShavitWtfdidVersion string $sha" "$plist"
+    old_sha=$(/usr/libexec/PlistBuddy -c "Print :ComYuvalShavitWtfdidVersion" "$plist" || echo '<none>')
+    if [[ "$old_sha" != "$sha" ]] ; then
+      echo "Updating sha to $sha (was: $old_sha)"
+      /usr/libexec/PlistBuddy -c "Delete :ComYuvalShavitWtfdidVersion" "$plist" || true
+      /usr/libexec/PlistBuddy -c "Add :ComYuvalShavitWtfdidVersion string $sha" "$plist"
+    else
+      echo "Found old sha ($sha), leaving untouched."
+    fi
   else
     echo "Missing plist: $plist"
   fi

--- a/wtfdid.xcodeproj/project.pbxproj
+++ b/wtfdid.xcodeproj/project.pbxproj
@@ -207,7 +207,7 @@
 				7E8C04D623714F0700A0C3A6 /* Sources */,
 				7E8C04D723714F0700A0C3A6 /* Frameworks */,
 				7E8C04D823714F0700A0C3A6 /* Resources */,
-				7E1C2F4F24CE33780070D8CD /* ShellScript */,
+				7E1C2F4F24CE33780070D8CD /* Set gitsha in Info.plist */,
 			);
 			buildRules = (
 			);
@@ -331,7 +331,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		7E1C2F4F24CE33780070D8CD /* ShellScript */ = {
+		7E1C2F4F24CE33780070D8CD /* Set gitsha in Info.plist */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -340,6 +340,7 @@
 			);
 			inputPaths = (
 			);
+			name = "Set gitsha in Info.plist";
 			outputFileListPaths = (
 			);
 			outputPaths = (

--- a/wtfdid/util/Version.swift
+++ b/wtfdid/util/Version.swift
@@ -1,64 +1,16 @@
 import Cocoa
 
 class Version: NSObject {
-    static let (major, minor, build) = Version.parseVersion()
-    
-    private static func parseVersion() -> (Int, Int, String) {
-        if let versionString = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
-            let splits = versionString.split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false)
-            var major = "0"
-            var minor = "0"
-            var build : String?
-            switch splits.count {
-            case 3:
-                build = String(splits[2])
-                fallthrough
-            case 2:
-                minor = String(splits[1])
-                fallthrough
-            case 1:
-                major = String(splits[0])
-            default:
-                NSLog("Unexpectedly found more than 3 splits from %@: %@", versionString, splits)
-            }
-            // The build number has to be a decimal digit, but it's actually an 8-digit hex.
-            var buildPretty : String
-            if let buildStr = build {
-                if var buildNum = UInt64(buildStr) {
-                    // A suffix of 0xffff means the build was git space was dirty
-                    // See buildscripts/set_plist_build.sh
-                    let gitDirtyMarker : String
-                    if buildNum & 0xffff == 0xffff {
-                        buildNum >>= 16
-                        gitDirtyMarker = "-dirty"
-                    } else {
-                        gitDirtyMarker = ""
-                    }
-                    buildPretty = String(format: "%x%@", buildNum, gitDirtyMarker)
-                } else {
-                    buildPretty = "x"
-                }
-            } else {
-                buildPretty = "0"
-            }
-            return (tryParse(major), tryParse(minor), buildPretty)
-        } else {
-            return (-1, -1, "x")
-        }
-    }
+    static let short = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?.?.?"
+    static let full = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?.?.?"
+    static let gitSha = Bundle.main.infoDictionary?["ComYuvalShavitWtfdidVersion"] as? String ?? "???????"
     
     static var pretty : String {
         get {
-            return "\(major).\(minor).\(build)"
-        }
-    }
-    
-    private static func tryParse(_ string: String) -> Int {
-        if let parsed = Int(string) {
-            return parsed
-        } else {
-            NSLog("Couldn't parse string: %@", string)
-            return -1
+            Bundle.main.infoDictionary?.forEach({(key, value) in
+                print("\(key) => \(value)")
+            })
+            return "\(short) (\(full) @\(gitSha))"
         }
     }
 }

--- a/wtfdid/util/Version.swift
+++ b/wtfdid/util/Version.swift
@@ -7,9 +7,6 @@ class Version: NSObject {
     
     static var pretty : String {
         get {
-            Bundle.main.infoDictionary?.forEach({(key, value) in
-                print("\(key) => \(value)")
-            })
             return "\(short) (\(full) @\(gitSha))"
         }
     }

--- a/wtfdid/util/Version.swift
+++ b/wtfdid/util/Version.swift
@@ -7,7 +7,7 @@ class Version: NSObject {
     
     static var pretty : String {
         get {
-            return "\(short) (\(full) @\(gitSha))"
+            return "\(short) (v\(full) @\(gitSha))"
         }
     }
 }


### PR DESCRIPTION
The previous system used the git sha as the patch number, but that doesn't always (or even usually!) increase. So, leave the version untouched, and stick the sha into a custom field instead.

Big thanks to https://stackoverflow.com/a/26354117/1076640.