### PR TITLE
don't focus when PTN is scheduled

### DIFF
--- a/whatdid/MainMenu.swift
+++ b/whatdid/MainMenu.swift
@@ -58,7 +58,6 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
             onOpen: {contents in
                 DispatchQueue.main.asyncAfter(deadline: DispatchTime.now()) {
                     self.open(contents)
-                    self.focus()
                 }
             },
             onSchedule: self.schedule)
@@ -72,6 +71,7 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
                 ? WindowContents.dailyEnd
                 : WindowContents.ptn
             opener.open(showWhat, reason: .manual)
+            self.focus()
         }
     }
     

--- a/whatdid/MainMenu.swift
+++ b/whatdid/MainMenu.swift
@@ -55,9 +55,12 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
         }
         
         opener = OpenCloseHelper<WindowContents>(
-            onOpen: {contents in
+            onOpen: {contents, reason in
                 DispatchQueue.main.asyncAfter(deadline: DispatchTime.now()) {
                     self.open(contents)
+                    if reason == .manual {
+                        self.focus()
+                    }
                 }
             },
             onSchedule: self.schedule)
@@ -71,7 +74,6 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
                 ? WindowContents.dailyEnd
                 : WindowContents.ptn
             opener.open(showWhat, reason: .manual)
-            self.focus()
         }
     }
     

--- a/whatdid/util/OpenCloseHelper.swift
+++ b/whatdid/util/OpenCloseHelper.swift
@@ -4,7 +4,7 @@ import Cocoa
 
 class OpenCloseHelper<T: Hashable & Comparable> {
     
-    private let opener: (T) -> Void
+    private let opener: (T, OpenReason) -> Void
     private let scheduler: (T) -> Void
     
     var openItem: T? = nil
@@ -12,7 +12,7 @@ class OpenCloseHelper<T: Hashable & Comparable> {
     private var rescheduleOnClose = false
     private var isSnoozed = false
     
-    init(onOpen: @escaping (T) -> Void, onSchedule: @escaping (T) -> Void) {
+    init(onOpen: @escaping (T, OpenReason) -> Void, onSchedule: @escaping (T) -> Void) {
         self.opener = onOpen
         self.scheduler = onSchedule
     }
@@ -23,7 +23,7 @@ class OpenCloseHelper<T: Hashable & Comparable> {
                 pendingOpens[item] = reason
             } else {
                 openItem = item
-                opener(item)
+                opener(item, reason)
                 rescheduleOnClose = reason == .scheduled
             }
         } else if reason == .scheduled {
@@ -71,7 +71,7 @@ class OpenCloseHelper<T: Hashable & Comparable> {
         if let deferredOpenKey = pendingOpens.keys.sorted().first {
             rescheduleOnClose = pendingOpens.removeValue(forKey: deferredOpenKey)! == .scheduled
             openItem = deferredOpenKey
-            opener(deferredOpenKey)
+            opener(deferredOpenKey, .scheduled)
         }
     }
 }

--- a/whatdidUITests/PtnViewControllerTest.swift
+++ b/whatdidUITests/PtnViewControllerTest.swift
@@ -143,6 +143,7 @@ class PtnViewControllerTest: XCTestCase {
                 type(into: app, entry("my project", "my task", "my notes"))
                 waitForTransition(of: .ptn, toIsVisible: false)
                 waitForTransition(of: .dailyEnd, toIsVisible: true)
+                add(XCTAttachment(screenshot: XCUIScreen.main.screenshot()))
             }
             group("Close the daily report") {
                 clickStatusMenu() // close the daily report


### PR DESCRIPTION
This includes a tweak to the OpenCloseHelper API, to have it pass the
open-reason down to the callback. That makes it blindly easy for the PTN
window to know whether it should focus itself: it should iff the window
was manually opened.

This also moves some focus-oriented tests that had been shoehorned into
testKeyboardNavigation() into their own test, and adds a new check for
the scheduled PTN. I've had enough focus-related issues that I think it
warrants having its own test.