### PR TITLE
add daily report's items right after attaching it

### DIFF
--- a/whatdid/DayEndReportController.swift
+++ b/whatdid/DayEndReportController.swift
@@ -33,7 +33,7 @@ class DayEndReportController: NSViewController {
         return result
     }
     
-    override func viewWillAppear() {
+    func prepareForViewing() {
         // Set the window's max height, using the golden ratio.
         if let screenHeight = view.window?.screen?.frame.height {
             maxViewHeight.constant = screenHeight * 0.61802903

--- a/whatdid/MainMenu.swift
+++ b/whatdid/MainMenu.swift
@@ -87,7 +87,9 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
     private func open(_ contents: WindowContents) {
         switch (contents) {
         case .dailyEnd:
-            window?.contentViewController = DayEndReportController()
+            let controller = DayEndReportController()
+            window?.contentViewController = controller
+            controller.prepareForViewing()
             window?.title = "Here's what you've been doing"
         case .ptn:
             window?.contentViewController = taskAdditionsPane


### PR DESCRIPTION
I'm not 100% sure why this works, tbh. But it does. It appears that the
system likes it if you add the view's subviews after you attach it to
the window. This fixes #112.

I did run the test without the prod-scope fixes, and was able to repro
the bug.