### PR TITLE
prompt to continue session or start new one after 6 hours

### DIFF
--- a/whatdid.xcodeproj/project.pbxproj
+++ b/whatdid.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		7E37A29C24C0293E005BA1DF /* Task+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E37A29824C0293E005BA1DF /* Task+CoreDataClass.swift */; };
 		7E37A29D24C0293E005BA1DF /* Task+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E37A29924C0293E005BA1DF /* Task+CoreDataProperties.swift */; };
 		7E4778F024F8F177007BAE8C /* AutocompleteFieldHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4778EF24F8F177007BAE8C /* AutocompleteFieldHelper.swift */; };
+		7E579F702503E2920055D9F6 /* SystemClockSchedulerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E579F6F2503E2910055D9F6 /* SystemClockSchedulerTest.swift */; };
 		7E64F02B24FAF01700C988C5 /* XCUIElementQuery+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E64F02A24FAF01700C988C5 /* XCUIElementQuery+Helpers.swift */; };
 		7E6F2E6D24F38D9E008874FE /* XCTestCase+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6F2E6C24F38D9E008874FE /* XCTestCase+Helpers.swift */; };
 		7E7B7E6124F2F84000460BC3 /* NSStackView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B7E6024F2F84000460BC3 /* NSStackView+Helpers.swift */; };
@@ -97,6 +98,7 @@
 		7E37A29824C0293E005BA1DF /* Task+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Task+CoreDataClass.swift"; sourceTree = "<group>"; };
 		7E37A29924C0293E005BA1DF /* Task+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Task+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		7E4778EF24F8F177007BAE8C /* AutocompleteFieldHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocompleteFieldHelper.swift; sourceTree = "<group>"; };
+		7E579F6F2503E2910055D9F6 /* SystemClockSchedulerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemClockSchedulerTest.swift; sourceTree = "<group>"; };
 		7E64F02A24FAF01700C988C5 /* XCUIElementQuery+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElementQuery+Helpers.swift"; sourceTree = "<group>"; };
 		7E6F2E6C24F38D9E008874FE /* XCTestCase+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Helpers.swift"; sourceTree = "<group>"; };
 		7E7B7E6024F2F84000460BC3 /* NSStackView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSStackView+Helpers.swift"; sourceTree = "<group>"; };
@@ -197,6 +199,14 @@
 			path = model;
 			sourceTree = "<group>";
 		};
+		7E579F6E2503E2740055D9F6 /* scheduling */ = {
+			isa = PBXGroup;
+			children = (
+				7E579F6F2503E2910055D9F6 /* SystemClockSchedulerTest.swift */,
+			);
+			path = scheduling;
+			sourceTree = "<group>";
+		};
 		7E7C385024DF36B300CFF3E7 /* model */ = {
 			isa = PBXGroup;
 			children = (
@@ -250,6 +260,7 @@
 		7E8C04ED23714F0800A0C3A6 /* whatdidTests */ = {
 			isa = PBXGroup;
 			children = (
+				7E579F6E2503E2740055D9F6 /* scheduling */,
 				7E970D6524DA81A400F634AB /* ui_testhook */,
 				7EE9A1C024DA35F200EE0FB1 /* util */,
 				7E8C04F023714F0800A0C3A6 /* Info.plist */,
@@ -549,6 +560,7 @@
 			files = (
 				7EEF324824EA54AD002E217A /* NSRange+HelpersTest.swift in Sources */,
 				7EE0E74224E4DF8A002D03F8 /* SubsequenceMatcherTest.swift in Sources */,
+				7E579F702503E2920055D9F6 /* SystemClockSchedulerTest.swift in Sources */,
 				7EF8579524E0961E00867832 /* OpenCloseHelperTest.swift in Sources */,
 				7EAB5ECD24DA366600E18097 /* TimeUtilTest.swift in Sources */,
 			);

--- a/whatdid.xcodeproj/project.pbxproj
+++ b/whatdid.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		7E4778F024F8F177007BAE8C /* AutocompleteFieldHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4778EF24F8F177007BAE8C /* AutocompleteFieldHelper.swift */; };
 		7E579F702503E2920055D9F6 /* SystemClockSchedulerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E579F6F2503E2910055D9F6 /* SystemClockSchedulerTest.swift */; };
 		7E64F02B24FAF01700C988C5 /* XCUIElementQuery+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E64F02A24FAF01700C988C5 /* XCUIElementQuery+Helpers.swift */; };
+		7E6C98D22503EF4900A712EB /* DelegatingScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6C98D12503EF4900A712EB /* DelegatingScheduler.swift */; };
+		7E6C98D42503F5C600A712EB /* DelegatingSchedulerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6C98D32503F5C600A712EB /* DelegatingSchedulerTest.swift */; };
+		7E6C98D62506B67F00A712EB /* DummyScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6C98D52506B67F00A712EB /* DummyScheduler.swift */; };
 		7E6F2E6D24F38D9E008874FE /* XCTestCase+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6F2E6C24F38D9E008874FE /* XCTestCase+Helpers.swift */; };
 		7E7B7E6124F2F84000460BC3 /* NSStackView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B7E6024F2F84000460BC3 /* NSStackView+Helpers.swift */; };
 		7E7C384B24DF2E5E00CFF3E7 /* FlatEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C384A24DF2E5E00CFF3E7 /* FlatEntry.swift */; };
@@ -100,6 +103,9 @@
 		7E4778EF24F8F177007BAE8C /* AutocompleteFieldHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocompleteFieldHelper.swift; sourceTree = "<group>"; };
 		7E579F6F2503E2910055D9F6 /* SystemClockSchedulerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemClockSchedulerTest.swift; sourceTree = "<group>"; };
 		7E64F02A24FAF01700C988C5 /* XCUIElementQuery+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElementQuery+Helpers.swift"; sourceTree = "<group>"; };
+		7E6C98D12503EF4900A712EB /* DelegatingScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegatingScheduler.swift; sourceTree = "<group>"; };
+		7E6C98D32503F5C600A712EB /* DelegatingSchedulerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegatingSchedulerTest.swift; sourceTree = "<group>"; };
+		7E6C98D52506B67F00A712EB /* DummyScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyScheduler.swift; sourceTree = "<group>"; };
 		7E6F2E6C24F38D9E008874FE /* XCTestCase+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Helpers.swift"; sourceTree = "<group>"; };
 		7E7B7E6024F2F84000460BC3 /* NSStackView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSStackView+Helpers.swift"; sourceTree = "<group>"; };
 		7E7C384A24DF2E5E00CFF3E7 /* FlatEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlatEntry.swift; sourceTree = "<group>"; };
@@ -203,6 +209,8 @@
 			isa = PBXGroup;
 			children = (
 				7E579F6F2503E2910055D9F6 /* SystemClockSchedulerTest.swift */,
+				7E6C98D32503F5C600A712EB /* DelegatingSchedulerTest.swift */,
+				7E6C98D52506B67F00A712EB /* DummyScheduler.swift */,
 			);
 			path = scheduling;
 			sourceTree = "<group>";
@@ -349,6 +357,7 @@
 				7EE4E39524E24A3F00552AAF /* ManualTickSchedulerWindow.swift */,
 				7EE4E39724E2523F00552AAF /* SystemClockScheduler.swift */,
 				7EE4E39924E25C0200552AAF /* DefaultScheduler.swift */,
+				7E6C98D12503EF4900A712EB /* DelegatingScheduler.swift */,
 			);
 			path = scheduling;
 			sourceTree = "<group>";
@@ -547,6 +556,7 @@
 				7E37A29A24C0293E005BA1DF /* Entry+CoreDataClass.swift in Sources */,
 				7EE0E74024E4DF4A002D03F8 /* SubsequenceMatcher.swift in Sources */,
 				7E970D6B24DA850D00F634AB /* UiTestWindow.swift in Sources */,
+				7E6C98D22503EF4900A712EB /* DelegatingScheduler.swift in Sources */,
 				7EDA369524D6A95B00F5E368 /* TimeUtil.swift in Sources */,
 				7E37A29D24C0293E005BA1DF /* Task+CoreDataProperties.swift in Sources */,
 				7EA1DFC024CA99BF003AD2BC /* MainMenu.swift in Sources */,
@@ -559,6 +569,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				7EEF324824EA54AD002E217A /* NSRange+HelpersTest.swift in Sources */,
+				7E6C98D62506B67F00A712EB /* DummyScheduler.swift in Sources */,
+				7E6C98D42503F5C600A712EB /* DelegatingSchedulerTest.swift in Sources */,
 				7EE0E74224E4DF8A002D03F8 /* SubsequenceMatcherTest.swift in Sources */,
 				7E579F702503E2920055D9F6 /* SystemClockSchedulerTest.swift in Sources */,
 				7EF8579524E0961E00867832 /* OpenCloseHelperTest.swift in Sources */,

--- a/whatdid/DayEndReportController.swift
+++ b/whatdid/DayEndReportController.swift
@@ -14,8 +14,9 @@ class DayEndReportController: NSViewController {
     @IBOutlet weak var projectsScrollHeight: NSLayoutConstraint!
     @IBOutlet weak var projectsContainer: NSStackView!
     @IBOutlet weak var entryStartDatePicker: NSDatePicker!
-    
     @IBOutlet weak var versionLabel: NSTextField!
+    
+    var scheduler: Scheduler = DefaultScheduler.instance
     
     override func awakeFromNib() {
         if #available(OSX 10.15.4, *) {
@@ -40,7 +41,7 @@ class DayEndReportController: NSViewController {
             NSLog("set max height to %.1f (screen height is %.1f)", maxViewHeight.constant, screenHeight)
         }
         // Set up the date picker
-        let now = DefaultScheduler.instance.now
+        let now = scheduler.now
         entryStartDatePicker.maxDate = now
         entryStartDatePicker.dateValue = thisMorning(assumingNow: now)
         
@@ -76,7 +77,7 @@ class DayEndReportController: NSViewController {
         
         let projects = Model.GroupedProjects(from: AppDelegate.instance.model.listEntries(since: since))
         let allProjectsTotalTime = projects.totalTime
-        let todayStart = thisMorning(assumingNow: DefaultScheduler.instance.now)
+        let todayStart = thisMorning(assumingNow: scheduler.now)
         projects.forEach {project in
             // The vstack group for the whole project
             let projectVStack = NSStackView()
@@ -110,7 +111,7 @@ class DayEndReportController: NSViewController {
             let timeFormatter = DateFormatter()
             timeFormatter.locale = Locale(identifier: "en_US_POSIX")
             timeFormatter.dateFormat = "h:mma"
-            timeFormatter.timeZone = DefaultScheduler.instance.timeZone
+            timeFormatter.timeZone = scheduler.timeZone
             timeFormatter.amSymbol = "am"
             timeFormatter.pmSymbol = "pm"
             

--- a/whatdid/MainMenu.swift
+++ b/whatdid/MainMenu.swift
@@ -65,7 +65,7 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
         opener = OpenCloseHelper<WindowContents>(
             onOpen: {ctx in
                 NSLog("MainMenu handling \(ctx.reason) open request for \(ctx.item)")
-                self.open(ctx.item)
+                self.open(ctx.item, scheduler: ctx.scheduler)
                 if ctx.reason == .manual {
                     self.focus()
                 }
@@ -84,14 +84,20 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
         }
     }
     
-    private func open(_ contents: WindowContents) {
+    private func open(_ contents: WindowContents, scheduler: Scheduler?) {
         switch (contents) {
         case .dailyEnd:
             let controller = DayEndReportController()
             window?.contentViewController = controller
             controller.prepareForViewing()
+            if let newScheduler = scheduler {
+                controller.scheduler = newScheduler
+            }
             window?.title = "Here's what you've been doing"
         case .ptn:
+            if let newScheduler = scheduler {
+                taskAdditionsPane.scheduler = newScheduler
+            }
             window?.contentViewController = taskAdditionsPane
             window?.title = "What are you working on?"
         }
@@ -132,7 +138,7 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
             NSApp.activate(ignoringOtherApps: true)
         }
         if !(window?.isVisible ?? false) {
-            open(.ptn)
+            open(.ptn, scheduler: nil)
         }
         window?.makeKeyAndOrderFront(self)
         if window?.contentView == taskAdditionsPane.view {

--- a/whatdid/MainMenu.swift
+++ b/whatdid/MainMenu.swift
@@ -63,10 +63,10 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
         statusItem.button?.action = #selector(handleStatusItemPress)
         
         opener = OpenCloseHelper<WindowContents>(
-            onOpen: {contents, reason in
-                NSLog("MainMenu handling \(reason) open request for \(contents)")
-                self.open(contents)
-                if reason == .manual {
+            onOpen: {ctx in
+                NSLog("MainMenu handling \(ctx.reason) open request for \(ctx.item)")
+                self.open(ctx.item)
+                if ctx.reason == .manual {
                     self.focus()
                 }
             },

--- a/whatdid/PtnViewController.swift
+++ b/whatdid/PtnViewController.swift
@@ -187,6 +187,15 @@ class PtnViewController: NSViewController {
         }
     }
     
+    override func viewWillDisappear() {
+        if let window = view.window {
+            for sheet in window.sheets {
+                window.endSheet(sheet, returnCode: .abort)
+            }
+        }
+        super.viewWillDisappear()
+    }
+    
     private func showNewSessionPrompt() {
         if let window = view.window {
             
@@ -227,9 +236,12 @@ class PtnViewController: NSViewController {
                 case .continue:
                     NSLog("Continuing with existing session")
                     startNewSession = false
+                case .abort:
+                    NSLog("Aborting window (probably because user closed it via status menu item)")
+                    startNewSession = false
                 default:
                     NSLog("Unexpected response: \(response.rawValue). Will start new session session.")
-                    startNewSession = true
+                    startNewSession = false
                 }
                 if startNewSession {
                     AppDelegate.instance.model.setLastEntryDateToNow()

--- a/whatdid/PtnViewController.swift
+++ b/whatdid/PtnViewController.swift
@@ -3,6 +3,7 @@
 import Cocoa
 
 class PtnViewController: NSViewController {
+    private static let TIME_UNTIL_NEW_SESSION_PROMPT = TimeInterval(6 * 60 * 60)
     @IBOutlet var topStack: NSStackView!
     
     @IBOutlet weak var projectField: AutoCompletingField!
@@ -69,6 +70,12 @@ class PtnViewController: NSViewController {
         projectField.nextKeyView = taskField
         taskField.nextKeyView = noteField
         noteField.nextKeyView = projectField
+        
+        if AppDelegate.instance.model.timeSinceLastEntry > PtnViewController.TIME_UNTIL_NEW_SESSION_PROMPT {
+            showNewSessionPrompt()
+        } else {
+            scheduler.schedule(after: PtnViewController.TIME_UNTIL_NEW_SESSION_PROMPT, showNewSessionPrompt)
+        }
     }
     
     override func viewWillAppear() {
@@ -135,6 +142,12 @@ class PtnViewController: NSViewController {
     }
     
     func grabFocus() {
+        if (view.window?.sheets ?? []).isEmpty {
+            grabFocusEvenIfHasSheet()
+        }
+    }
+    
+    private func grabFocusEvenIfHasSheet() {
         perform(#selector(grabFocusNow), with: nil, afterDelay: TimeInterval.zero, inModes: [RunLoop.Mode.common])
     }
     
@@ -171,6 +184,60 @@ class PtnViewController: NSViewController {
             AppDelegate.instance.model.addBreakEntry(
                 callback: closeAction
             )
+        }
+    }
+    
+    private func showNewSessionPrompt() {
+        if let window = view.window {
+            
+            let sheet = NSWindow(contentRect: window.contentView!.frame, styleMask: [], backing: .buffered, defer: true)
+            let mainStack = NSStackView()
+            mainStack.orientation = .vertical
+            mainStack.useAutoLayout()
+            mainStack.edgeInsets = NSEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+            sheet.contentView = mainStack
+            
+            let headerLabel = NSTextField(labelWithString: "It's been a while since you last checked in.")
+            headerLabel.font = NSFont.boldSystemFont(ofSize: NSFont.labelFontSize * 1.25)
+            mainStack.addArrangedSubview(headerLabel)
+            
+            let optionsStack = NSStackView()
+            optionsStack.useAutoLayout()
+            mainStack.addArrangedSubview(optionsStack)
+            optionsStack.orientation = .horizontal
+            optionsStack.widthAnchor.constraint(equalTo: mainStack.widthAnchor).isActive = true
+            optionsStack.addView(
+                ButtonWithClosure(label: "Start new session") {_ in
+                    window.endSheet(sheet, returnCode: .OK)
+                },
+                in: .center)
+            optionsStack.addView(
+                ButtonWithClosure(label: "Continue with current session") {_ in
+                    window.endSheet(sheet, returnCode: .continue)
+                },
+            in: .center)
+            
+            window.makeFirstResponder(nil)
+            window.beginSheet(sheet) {response in
+                let startNewSession: Bool
+                switch(response) {
+                case .OK:
+                    NSLog("Starting new session")
+                    startNewSession = true
+                case .continue:
+                    NSLog("Continuing with existing session")
+                    startNewSession = false
+                default:
+                    NSLog("Unexpected response: \(response.rawValue). Will start new session session.")
+                    startNewSession = true
+                }
+                if startNewSession {
+                    AppDelegate.instance.model.setLastEntryDateToNow()
+                    self.closeAction()
+                } else {
+                    self.grabFocusEvenIfHasSheet()
+                }
+            }
         }
     }
 }

--- a/whatdid/PtnViewController.swift
+++ b/whatdid/PtnViewController.swift
@@ -18,6 +18,8 @@ class PtnViewController: NSViewController {
     
     var closeAction : () -> Void = {}
     
+    var scheduler: Scheduler = DefaultScheduler.instance
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         projectField.textField.placeholderString = "project"
@@ -78,12 +80,12 @@ class PtnViewController: NSViewController {
         let bufferMinutes = 10
         let formatter = DateFormatter()
         let snoozeIntervalMinutes = 30.0
-        formatter.timeZone = DefaultScheduler.instance.timeZone
+        formatter.timeZone = scheduler.timeZone
         formatter.dateFormat = "h:mm a"
         formatter.amSymbol = "am"
         formatter.pmSymbol = "pm"
         
-        var snoozeUntil = DefaultScheduler.instance.now.addingTimeInterval(TimeInterval(bufferMinutes * 60))
+        var snoozeUntil = scheduler.now.addingTimeInterval(TimeInterval(bufferMinutes * 60))
         // Round it up (always up) to the nearest half-hour
         let incrementInterval = Double(snoozeIntervalMinutes * 60.0)
         snoozeUntil = Date(timeIntervalSince1970: (snoozeUntil.timeIntervalSince1970 / incrementInterval).rounded(.up) * incrementInterval)

--- a/whatdid/model/Model.swift
+++ b/whatdid/model/Model.swift
@@ -49,6 +49,10 @@ class Model {
         lastEntryDate = DefaultScheduler.instance.now
     }
     
+    var timeSinceLastEntry: TimeInterval {
+        return DefaultScheduler.instance.now.timeIntervalSince(lastEntryDate)
+    }
+    
     func listProjects() -> [Project] {
         var result : [Project]!
         container.viewContext.performAndWait {

--- a/whatdid/scheduling/DelegatingScheduler.swift
+++ b/whatdid/scheduling/DelegatingScheduler.swift
@@ -1,0 +1,88 @@
+// whatdid?
+
+import Cocoa
+
+class DelegatingScheduler: Scheduler {
+    private let delegate: Scheduler
+    private var tasks = [UUID: ScheduledTask]()
+    private var isOpen = true
+    
+    init(delegateTo delegate: Scheduler) {
+        self.delegate = delegate
+    }
+    
+    var now: Date {
+        delegate.now
+    }
+    
+    var timeZone: TimeZone {
+        delegate.timeZone
+    }
+    
+    /// The number of tasks currently being tracked by this scheduler. Intended for testing (to ensure there are no memory leaks).
+    var tasksCount: Int {
+        return tasks.count
+    }
+    
+    @discardableResult func schedule(at: Date, _ block: @escaping () -> Void) -> ScheduledTask {
+        guard isOpen else {
+            NSLog("Ignoring task because DelegatingScheduler has been closed")
+            return NoopTask()
+        }
+        let work = createTrackingBlock(block)
+        work.tracks = delegate.schedule(at: at, work.run)
+        return work
+    }
+    
+    @discardableResult func schedule(after: TimeInterval, _ block: @escaping () -> Void) -> ScheduledTask {
+        guard isOpen else {
+            NSLog("Ignoring task because DelegatingScheduler has been closed")
+            return NoopTask()
+        }
+        let work = createTrackingBlock(block)
+        work.tracks = delegate.schedule(after: after, work.run)
+        return work
+    }
+    
+    func close() {
+        for id in tasks.keys {
+            let task = tasks.removeValue(forKey: id)
+            task?.cancel()
+        }
+        isOpen = false
+    }
+    
+    private func createTrackingBlock(_ block: @escaping () -> Void) -> Tracker {
+        let tracker = Tracker(parent: self, task: block)
+        tasks[tracker.id] = tracker
+        return tracker
+    }
+    
+    private struct NoopTask: ScheduledTask {
+        func cancel() {
+            // nothing
+        }
+    }
+    
+    private class Tracker: ScheduledTask {
+        let id = UUID()
+        let parent: DelegatingScheduler
+        let task: () -> Void
+        var tracks: ScheduledTask? = nil
+        
+        init(parent: DelegatingScheduler, task: @escaping () -> Void) {
+            self.parent = parent
+            self.task = task
+        }
+        
+        func run() {
+            parent.tasks.removeValue(forKey: id)
+            task()
+        }
+        
+        func cancel() {
+            parent.tasks.removeValue(forKey: id)
+            tracks?.cancel()
+        }
+    }
+}

--- a/whatdid/scheduling/Scheduler.swift
+++ b/whatdid/scheduling/Scheduler.swift
@@ -5,8 +5,12 @@ import Foundation
 protocol Scheduler {
     var now: Date { get }
     var timeZone: TimeZone { get }
-    func schedule(at: Date, _ block: @escaping () -> Void)
-    func schedule(after: TimeInterval, _ block: @escaping () -> Void)
+    @discardableResult func schedule(at: Date, _ block: @escaping () -> Void) -> ScheduledTask
+    @discardableResult func schedule(after: TimeInterval, _ block: @escaping () -> Void) -> ScheduledTask
+}
+
+protocol ScheduledTask {
+    func cancel()
 }
 
 extension Date {

--- a/whatdid/scheduling/SystemClockScheduler.swift
+++ b/whatdid/scheduling/SystemClockScheduler.swift
@@ -13,17 +13,31 @@ class SystemClockScheduler: Scheduler {
         return TimeZone.autoupdatingCurrent
     }
     
-    func schedule(at date: Date, _ block: @escaping () -> Void) {
+    func schedule(at date: Date, _ block: @escaping () -> Void) -> ScheduledTask {
         let tolerence = SystemClockScheduler.TOLERANCE_SECONDS * 2
         let adjustedDate = date.addingTimeInterval(-tolerence)
         let timer = Timer(fire: adjustedDate, interval: 0, repeats: false, block: {_ in block()})
         timer.tolerance = tolerence
         RunLoop.current.add(timer, forMode: .default)
+        return TimerBasedScheduledTask(timer: timer)
     }
     
-    func schedule(after: TimeInterval, _ block: @escaping () -> Void) {
+    func schedule(after: TimeInterval, _ block: @escaping () -> Void) -> ScheduledTask {
         let wakeupTime = DispatchWallTime.now() + .seconds(Int(after))
-        DispatchQueue.main.asyncAfter(wallDeadline: wakeupTime, execute: block)
+        let dispatchWorkItem = DispatchWorkItem(block: block)
+        DispatchQueue.main.asyncAfter(wallDeadline: wakeupTime, execute: dispatchWorkItem)
+        return dispatchWorkItem
     }
-    
+}
+
+private struct TimerBasedScheduledTask: ScheduledTask {
+   let timer: Timer
+   
+   func cancel() {
+       timer.invalidate()
+   }
+}
+
+extension DispatchWorkItem: ScheduledTask {
+    // ScheduledTask.cancel() is already defined
 }

--- a/whatdid/util/ButtonWithClosure.swift
+++ b/whatdid/util/ButtonWithClosure.swift
@@ -6,6 +6,11 @@ class ButtonWithClosure: NSButton {
 
     private var handlers = [(NSButton) -> Void]()
     
+    convenience init(label: String, _ handler: @escaping (NSButton) -> Void) {
+        self.init(title: label, target: nil, action: nil)
+        onPress(handler)
+    }
+    
     override func sendAction(_ action: Selector?, to target: Any?) -> Bool {
         let result = super.sendAction(action, to: target) || (!handlers.isEmpty)
         handlers.forEach {handler in handler(self)}

--- a/whatdidTests/scheduling/DelegatingSchedulerTest.swift
+++ b/whatdidTests/scheduling/DelegatingSchedulerTest.swift
@@ -1,0 +1,92 @@
+// whatdidTests?
+
+import XCTest
+@testable import whatdid
+
+class DelegatingSchedulerTest: XCTestCase {
+
+    func testSingleTaskCanceled() {
+        let dummy = DummyScheduler()
+        let delegate = DelegatingScheduler(delegateTo: dummy)
+        var count = 0
+        
+        let task = delegate.schedule(after: 0) { count += 1 }
+        XCTAssertEqual(1, delegate.tasksCount)
+        XCTAssertEqual(0, count)
+        
+        task.cancel()
+        XCTAssertEqual(0, delegate.tasksCount)
+        XCTAssertEqual(0, count)
+        
+        dummy.runAllScheduled()
+        XCTAssertEqual(0, count)
+    }
+    
+    func testAllTasksCanceled() {
+        let dummy = DummyScheduler()
+        let delegate = DelegatingScheduler(delegateTo: dummy)
+        var count = 0
+        
+        delegate.schedule(after: 0) { count += 1 }
+        XCTAssertEqual(1, delegate.tasksCount)
+        XCTAssertEqual(0, count)
+        
+        delegate.close()
+        XCTAssertEqual(0, delegate.tasksCount)
+        XCTAssertEqual(0, count)
+        
+        dummy.runAllScheduled()
+        XCTAssertEqual(0, count)
+    }
+    
+    func testClosedSchedulerIgnoresNewTasks() {
+        let dummy = DummyScheduler()
+        let delegate = DelegatingScheduler(delegateTo: dummy)
+        var count = 0
+        
+        delegate.close()
+        XCTAssertEqual(0, delegate.tasksCount)
+        XCTAssertEqual(0, count)
+        
+        delegate.schedule(after: 0) { count += 1 }
+        XCTAssertEqual(0, delegate.tasksCount)
+        XCTAssertEqual(0, count)
+        
+        dummy.runAllScheduled()
+        XCTAssertEqual(0, delegate.tasksCount)
+        XCTAssertEqual(0, count)
+    }
+    
+    func testSingleTaskRuns() {
+        let dummy = DummyScheduler()
+        let delegate = DelegatingScheduler(delegateTo: dummy)
+        var count = 0
+        
+        delegate.schedule(after: 0) { count += 1 }
+        XCTAssertEqual(1, delegate.tasksCount)
+        XCTAssertEqual(0, count)
+        
+        dummy.runAllScheduled()
+        XCTAssertEqual(0, delegate.tasksCount)
+        XCTAssertEqual(1, count)
+    }
+    
+    func testSingleTaskRunsThenIsCanceled() {
+        let dummy = DummyScheduler()
+        let delegate = DelegatingScheduler(delegateTo: dummy)
+        var count = 0
+        
+        let task = delegate.schedule(after: 0) { count += 1 }
+        XCTAssertEqual(1, delegate.tasksCount)
+        XCTAssertEqual(0, count)
+        
+        dummy.runAllScheduled()
+        XCTAssertEqual(0, delegate.tasksCount)
+        XCTAssertEqual(1, count)
+        
+        task.cancel() // should be noop
+        dummy.runAllScheduled()
+        XCTAssertEqual(0, delegate.tasksCount)
+        XCTAssertEqual(1, count)
+    }
+}

--- a/whatdidTests/scheduling/DummyScheduler.swift
+++ b/whatdidTests/scheduling/DummyScheduler.swift
@@ -1,0 +1,49 @@
+// whatdidTests?
+
+import Cocoa
+@testable import whatdid
+
+/// A Scheduler that doesn't depend on any system clock.
+/// Instead, its tasks get enqueued until you manually run them via `runAllScheduled`. Useful for unit tests involving schedulers.
+class DummyScheduler: Scheduler {
+    private var tasks = [DummyScheduledTask]()
+    let now = Date()
+    let timeZone = TimeZone.current
+    
+    func runAllScheduled() {
+        for task in tasks {
+            if !task.isCanceled && !task.hasRun {
+                task.hasRun = true
+                task.block()
+            }
+        }
+    }
+    
+    func schedule(at: Date, _ block: @escaping () -> Void) -> ScheduledTask {
+        return add(block)
+    }
+    
+    func schedule(after: TimeInterval, _ block: @escaping () -> Void) -> ScheduledTask {
+        return add(block)
+    }
+    
+    private func add(_ block: @escaping () -> Void) -> ScheduledTask {
+        let task = DummyScheduledTask(block)
+        tasks.append(task)
+        return task
+    }
+    
+    class DummyScheduledTask: ScheduledTask {
+        let block: () -> Void
+        var hasRun = false
+        var isCanceled = false
+        
+        init(_ block: @escaping () -> Void) {
+            self.block = block
+        }
+        
+        func cancel() {
+            isCanceled = true
+        }
+    }
+}

--- a/whatdidTests/scheduling/SystemClockSchedulerTest.swift
+++ b/whatdidTests/scheduling/SystemClockSchedulerTest.swift
@@ -1,0 +1,89 @@
+// whatdidTests?
+
+import XCTest
+@testable import whatdid
+
+class SystemClockSchedulerTest: XCTestCase {
+    private static let delay = TimeInterval(5)
+    
+    static let scheduler = SystemClockScheduler()
+
+    /// A single test for all checks. Since the tests have a delay (and need it, since we're testing schedules), this lets us save wall-clock time by
+    /// doing them all in parallel.
+    func testScheduling() {
+        let checks = XCTContext.runActivity(named: "create checks") {(XCTActivity) -> [SingleCheck] in
+            let checks = DelayStrategy.allCases.flatMap{[($0, true), ($0, false)]}.map{SingleCheck(delay: $0.0, willBeCanceled: $0.1)}
+            XCTAssertEqual(4, checks.count) // sanity check
+            
+            checks.forEach { $0.start() }
+            checks.filter{$0.shouldGetCanceled}.forEach {check in
+                XCTAssertNotNil(check.scheduledTask, check.description)
+                check.scheduledTask?.cancel()
+            }
+            return checks
+        }
+        XCTContext.runActivity(named: "wait for checks to run") {_ in
+            print("Waiting for checks to run")
+            wait(for: checks.compactMap{$0.expectation}, timeout: SystemClockSchedulerTest.delay * 2)
+            sleep(1) // If any canceled tasks were going to happen, this gives them time to happen
+        }
+        XCTContext.runActivity(named: "check results") {_ in
+            checks.forEach {check in
+                XCTAssertEqual(check.shouldGetCanceled, !check.timerFired, check.description)
+            }
+        }
+    }
+    
+    func testCancelTaskAfterItRuns() {
+        let expectation = XCTestExpectation()
+        var count = 0
+        let scheduledTask = SystemClockSchedulerTest.scheduler.schedule(after: 0.1) {
+            count += 1
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
+        XCTAssertEqual(1, count)
+        
+        scheduledTask.cancel() // should be noop
+        XCTAssertEqual(1, count)
+    }
+    
+    class SingleCheck: CustomStringConvertible {
+        private let delayStrategy: DelayStrategy
+        var timerFired = false
+        let expectation: XCTestExpectation?
+        let description: String
+        let shouldGetCanceled: Bool
+        var scheduledTask: ScheduledTask?
+        
+        init(delay: DelayStrategy, willBeCanceled: Bool) {
+            self.delayStrategy = delay
+            self.shouldGetCanceled = willBeCanceled
+            
+            let delayDesc = String(describing: delayStrategy)
+            let expectedDesc = shouldGetCanceled ? "will be canceled" : "will not be canceled"
+            description = "\(delayDesc) \(expectedDesc)"
+            self.expectation = shouldGetCanceled ? nil : XCTestExpectation()
+        }
+        
+        func start(){
+            switch delayStrategy {
+            case .byDate:
+                scheduledTask = SystemClockSchedulerTest.scheduler.schedule(at: Date().addingTimeInterval(SystemClockSchedulerTest.delay), setResult)
+            case .byInterval:
+                scheduledTask = SystemClockSchedulerTest.scheduler.schedule(after: SystemClockSchedulerTest.delay, setResult)
+            }
+        }
+        
+        private func setResult() {
+            timerFired = true
+            expectation?.fulfill()
+        }
+    }
+    
+    enum DelayStrategy: CaseIterable {
+        case byInterval
+        case byDate
+    }
+
+}

--- a/whatdidUITests/PtnViewControllerTest.swift
+++ b/whatdidUITests/PtnViewControllerTest.swift
@@ -160,10 +160,105 @@ class PtnViewControllerTest: XCTestCase {
         }
     }
     
+    func testLongSessionPrompt() {
+        group("Long session while PTN is open") {
+            clickStatusMenu()
+            setTimeUtc(d: 0, h: 5, m: 59, onSessionPrompt: .ignorePrompt)
+            checkLongSessionPrompt(exists: false)
+            setTimeUtc(d: 0, h: 6, m: 00, onSessionPrompt: .ignorePrompt)
+            checkLongSessionPrompt(exists: true)
+        }
+        group("New session resets the time") {
+            group("Select option to start new session") {
+                handleLongSessionPrompt(.startNewSession)
+                waitForTransition(of: .ptn, toIsVisible: false)
+            }
+            group("Create an entry") {
+                setTimeUtc(d: 0, h: 6, m: 5)
+                let ptn = openPtn()
+                type(into: ptn.window, entry("p1", "t2", "n3"))
+                waitForTransition(of: .ptn, toIsVisible: false)
+            }
+            group("Verify entry") {
+                let ptn = openPtn()
+                let entries = FlatEntry.deserialize(from: ptn.entriesHook.stringValue)
+                XCTAssertEqual(
+                    [FlatEntry(from: date(h: 6, m: 00), to: date(h: 6, m: 05), project: "p1", task: "t2", notes: "n3")],
+                    entries)
+                ptn.entriesHook.deleteText(andReplaceWith: "\r")
+            }
+        }
+        group("Long session while PTN is closed") {
+            group("Close PTN") {
+                clickStatusMenu()
+                waitForTransition(of: .ptn, toIsVisible: false)
+                waitForTransition(of: .dailyEnd, toIsVisible: false)
+            }
+            group("Go forward 6 more hours") {
+                setTimeUtc(d: 0, h: 12, m: 10, onSessionPrompt: .ignorePrompt)
+                checkLongSessionPrompt(exists: true)
+            }
+        }
+        group("Continuing session keeps the time") {
+            group("Select option to continue session") {
+                handleLongSessionPrompt(.continueWithCurrentSession)
+            }
+            group("Create an entry") {
+                setTimeUtc(d: 0, h: 12, m: 15)
+                let ptn = findPtn()
+                ptn.pcombo.textField.deleteText() // since it'll be pre-populated with the last "p1"
+                type(into: ptn.window, entry("pA", "tB", "nC"))
+                waitForTransition(of: .ptn, toIsVisible: false)
+            }
+            group("Verify entry") {
+                let ptn = openPtn()
+                let entries = FlatEntry.deserialize(from: ptn.entriesHook.stringValue)
+                XCTAssertEqual(
+                    [FlatEntry(from: date(h: 6, m: 05), to: date(h: 12, m: 15), project: "pA", task: "tB", notes: "nC")],
+                    entries)
+            }
+        }
+        group("Long session with contention with daily report") {
+            group("Wait until tomorrow") {
+                assertThat(window: .ptn, isVisible: true)
+                setTimeUtc(d: 1, h: 0, m: 0, onSessionPrompt: .ignorePrompt)
+            }
+            group("Close PTN and check for no sheet") {
+                clickStatusMenu()
+                waitForTransition(of: .ptn, toIsVisible: false)
+                checkLongSessionPrompt(exists: false)
+                waitForTransition(of: .dailyEnd, toIsVisible: true)
+                
+                clickStatusMenu()
+                waitForTransition(of: .ptn, toIsVisible: false)
+                waitForTransition(of: .dailyEnd, toIsVisible: false)
+            }
+            group("Re-open PTN and check for sheet") {
+                // Because we clicked out of the last PTN (and thus didn't either continue the session or start a new one),
+                // re-opening the PTN should cause us to be instantly re-prompted.
+                clickStatusMenu()
+                checkLongSessionPrompt(exists: true)
+                handleLongSessionPrompt(.startNewSession)
+            }
+        }
+        group("Long session prompt after PTN deferred by daily report") {
+            group("Open daily report and fast forward 6 hours") {
+                clickStatusMenu(with: .maskAlternate)
+                setTimeUtc(d: 1, h: 6, m: 1)
+                assertThat(window: .dailyEnd, isVisible: true)
+            }
+            group("Close daily report and confirm prompt in PTN") {
+                clickStatusMenu()
+                waitForTransition(of: .dailyEnd, toIsVisible: false)
+                wait(for: "PTN to exist", until: {app.windows[WindowType.ptn.windowTitle].exists})
+                checkLongSessionPrompt(exists: true)
+            }
+        }
+    }
+    
     func testAutoComplete() {
         let ptn = openPtn()
         group("initalize the data") {
-            let entriesTextField  = ptn.window.textFields["uihook_flatentryjson"]
             // Three entries, in shuffled alphabetical order (neither fully ascending or descending)
             // We want both the lowest and highest values (alphanumerically) to be in the middle.
             // That means that when we autocomplete "wh*", we can be sure that we're getting date-ordered
@@ -173,7 +268,7 @@ class PtnViewControllerTest: XCTestCase {
                 entry("whatdid", "autothing", "notes 1", from: t(-80), to: t(-70)),
                 entry("whytdid", "autothing", "notes 1", from: t(-80), to: t(-70)),
                 entry("whodid", "something else", "notes 2", from: t(-60), to: t(-50)))
-            entriesTextField.deleteText(andReplaceWith: entriesSerialized + "\r")
+            ptn.entriesHook.deleteText(andReplaceWith: entriesSerialized + "\r")
         }
         group("autocomplete wh*") {
             let pcombo = ptn.pcombo.textField
@@ -193,7 +288,7 @@ class PtnViewControllerTest: XCTestCase {
             .add(project: "project c", task: "task 2", notes: "fuzz", minutes: 10)
         group("Initalize the data") {
             let ptn = openPtn()
-            let entriesTextField  = ptn.window.textFields["uihook_flatentryjson"]
+            let entriesTextField  = ptn.entriesHook
             entriesTextField.deleteText(andReplaceWith: FlatEntry.serialize(entries.get()))
             entriesTextField.typeKey(.enter)
             clickStatusMenu()
@@ -219,8 +314,7 @@ class PtnViewControllerTest: XCTestCase {
             group("Close the report and set up contention") {
                 clickStatusMenu() // close daily report
                 let ptn = openPtn()
-                let entriesTextField = ptn.window.textFields["uihook_flatentryjson"]
-                entriesTextField.deleteText(andReplaceWith: FlatEntry.serialize(entries.get(startingAtSecondsSince1970: 86400)) + "\r")
+                ptn.entriesHook.deleteText(andReplaceWith: FlatEntry.serialize(entries.get(startingAtSecondsSince1970: 86400)) + "\r")
                 setTimeUtc(d: 1, h: 0, m: 0, onSessionPrompt: .startNewSession) // also closes the PTN
                 waitForTransition(of: .ptn, toIsVisible: false)
                 waitForTransition(of: .dailyEnd, toIsVisible: true)
@@ -278,13 +372,12 @@ class PtnViewControllerTest: XCTestCase {
             group("Set new entries") {
                 clickStatusMenu() // Close the daily report
                 let ptn = openPtn()
-                let entriesTextField = ptn.window.textFields["uihook_flatentryjson"]
                 let manyEntries = EntriesBuilder()
                 for i in 1...25 {
                     manyEntries.add(project: "project \(i)", task: "only task", notes: "", minutes: Double(i))
                 }
-                entriesTextField.deleteText(andReplaceWith: FlatEntry.serialize(manyEntries.get(startingAtSecondsSince1970: 86400)))
-                entriesTextField.typeKey(.enter)
+                ptn.entriesHook.deleteText(andReplaceWith: FlatEntry.serialize(manyEntries.get(startingAtSecondsSince1970: 86400)))
+                ptn.entriesHook.typeKey(.enter)
                 clickStatusMenu()
             }
             let project1Header = HierarchicalEntryLevel(ancestor: dailyReport, scope: "Project", label: "project 1").headerLabel
@@ -452,16 +545,20 @@ class PtnViewControllerTest: XCTestCase {
         }
     }
     
-    func handleLongSessionPrompt(_ action: LongSessionAction, checkForPrompt: Bool = false) {
-        let ptn = app.windows[WindowType.ptn.windowTitle]
-        let promptExists: Bool
-        if checkForPrompt {
-            wait(for: "long session prompt", until: {ptn.exists && ptn.sheets.count > 0})
-            promptExists = true
+    func checkLongSessionPrompt(exists: Bool) {
+        if exists {
+            let ptn = findPtn()
+            wait(for: "long session prompt", until: {ptn.window.exists && ptn.window.sheets.count > 0})
         } else {
-            promptExists = ptn.exists && ptn.sheets.count > 0
+            log("Waiting for a bit, in case a long session prompt is about to come up")
+            sleep(1)
+            XCTAssertEqual(0, ptnOrDailyReportWindow.sheets.count)
         }
-        if promptExists {
+    }
+    
+    func handleLongSessionPrompt(_ action: LongSessionAction) {
+        let ptn = app.windows[WindowType.ptn.windowTitle]
+        if ptn.exists && ptn.sheets.count > 0 {
             switch action {
             case .continueWithCurrentSession:
                 ptn.sheets.buttons["Continue with current session"].click()
@@ -470,9 +567,6 @@ class PtnViewControllerTest: XCTestCase {
             case .ignorePrompt:
                 break // nothing
             }
-        }
-        if checkForPrompt && !promptExists {
-            XCTFail("Required long session prompt, but it was absent.")
         }
     }
 
@@ -486,6 +580,17 @@ class PtnViewControllerTest: XCTestCase {
         }
     }
     
+    var ptnOrDailyReportWindow: XCUIElement {
+        for windowType in WindowType.allCases {
+            let maybe = app.windows[windowType.windowTitle]
+            if maybe.exists {
+                return maybe
+            }
+        }
+        XCTFail("Couldn't find PTN or daily report window")
+        return nil!
+    }
+    
     func pauseToLetStabilize() {
         sleepMillis(250)
     }
@@ -493,6 +598,11 @@ class PtnViewControllerTest: XCTestCase {
     func type(into app: XCUIElement, _ entry: FlatEntry) {
         app.comboBoxes["pcombo"].children(matching: .textField).firstMatch.click()
         app.typeText("\(entry.project)\r\(entry.task)\r\(entry.notes ?? "")\r")
+    }
+    
+    func date(d: Int = 0, h: Int, m: Int) -> Date {
+        let epochSeconds = d * 86400 + h * 3600 + m * 60
+        return Date(timeIntervalSince1970: TimeInterval(epochSeconds))
     }
     
     func entry(_ project: String, _ task: String, _ notes: String?) -> FlatEntry {
@@ -625,9 +735,13 @@ class PtnViewControllerTest: XCTestCase {
         var nfield: XCUIElement {
             window.textFields["nfield"]
         }
+        
+        var entriesHook: XCUIElement {
+            window.textFields["uihook_flatentryjson"]
+        }
     }
     
-    enum WindowType {
+    enum WindowType: CaseIterable {
         case ptn
         case dailyEnd
         

--- a/whatdidUITests/XCUIElement+Helpers.swift
+++ b/whatdidUITests/XCUIElement+Helpers.swift
@@ -69,10 +69,9 @@ extension XCUIElement {
                 click()
             }
             typeKey("a", modifierFlags: .command)
+            typeKey(.delete, modifierFlags:[])
             if let replacementToType = replacement {
                 typeText(replacementToType)
-            } else {
-                typeKey(.delete, modifierFlags:[])
             }
         }
     }


### PR DESCRIPTION
After 6 hours without a status update, the PTN will show a sheet asking the user if they want to continue with the current session or start a new one.

This PR includes a framework by which windows can set timers that get automatically canceled after the window goes away. For now, we just use this to set that 6-hour timer; future uses could be to change the snooze options after some time (#30) or to regularly update the PTN with how long it's been since the last update (#73).