### PR TITLE
replace Break button with "Skip session"

### DIFF
--- a/whatdid/PtnViewController.swift
+++ b/whatdid/PtnViewController.swift
@@ -9,7 +9,7 @@ class PtnViewController: NSViewController {
     @IBOutlet weak var projectField: AutoCompletingField!
     @IBOutlet weak var taskField: AutoCompletingField!
     @IBOutlet weak var noteField: NSTextField!
-    @IBOutlet weak var breakButton: NSButton!
+    @IBOutlet weak var skipButton: NSButton!
     
     @IBOutlet weak var snoozeButton: NSButton!
     private var snoozeUntil : Date?
@@ -43,18 +43,10 @@ class PtnViewController: NSViewController {
         }
         projectField.action = self.projectOrTaskAction
         taskField.action = self.projectOrTaskAction
-        setBreakButtonTitle()
         
         #if UI_TEST
         addJsonFlatEntryField()
         #endif
-    }
-    
-    func setBreakButtonTitle() {
-        let optionsToDisplay = breakButton.keyEquivalentModifierMask.subtracting(.option)
-        let combo = AppDelegate.keyComboString(keyEquivalent: breakButton.keyEquivalent, keyEquivalentMask: optionsToDisplay)
-        let name = optionIsPressed ? "Skip this session" : "Break"
-        breakButton.title = combo.isEmpty ? name : "\(name) (\(combo))"
     }
     
     func reset() {
@@ -126,21 +118,6 @@ class PtnViewController: NSViewController {
         }
     }
     
-    override func flagsChanged(with event: NSEvent) {
-        super.flagsChanged(with: event)
-        let optionIsNowPressed = event.modifierFlags.contains(.option)
-        if optionIsNowPressed != optionIsPressed {
-            optionIsPressed = optionIsNowPressed
-            if optionIsNowPressed {
-                breakButton.keyEquivalentModifierMask.insert(.option)
-            } else {
-                breakButton.keyEquivalentModifierMask.remove(.option)
-            }
-            setBreakButtonTitle()
-        }
-        
-    }
-    
     func grabFocus() {
         if (view.window?.sheets ?? []).isEmpty {
             grabFocusEvenIfHasSheet()
@@ -176,15 +153,9 @@ class PtnViewController: NSViewController {
         )
     }
     
-    @IBAction func breakButtonPressed(_ sender: Any) {
-        if optionIsPressed {
-            AppDelegate.instance.model.setLastEntryDateToNow()
-            closeAction()
-        } else {
-            AppDelegate.instance.model.addBreakEntry(
-                callback: closeAction
-            )
-        }
+    @IBAction func skipButtonPressed(_ sender: Any) {
+        AppDelegate.instance.model.setLastEntryDateToNow()
+        closeAction()
     }
     
     override func viewWillDisappear() {

--- a/whatdid/PtnViewController.xib
+++ b/whatdid/PtnViewController.xib
@@ -20,10 +20,10 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <stackView identifier="topstack" distribution="fill" orientation="vertical" alignment="trailing" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HWg-YQ-y10" userLabel="Top Stack">
-            <rect key="frame" x="0.0" y="0.0" width="544" height="91"/>
+            <rect key="frame" x="0.0" y="0.0" width="558" height="91"/>
             <subviews>
                 <stackView identifier="ptnstack" distribution="fill" orientation="horizontal" alignment="top" spacing="1" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BPo-6t-Flu" userLabel="PTN Stack">
-                    <rect key="frame" x="0.0" y="37" width="544" height="50"/>
+                    <rect key="frame" x="14" y="37" width="544" height="50"/>
                     <subviews>
                         <customView identifier="pcombo" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4Lo-U3-YED" userLabel="Project combo" customClass="AutoCompletingField" customModule="whatdid" customModuleProvider="target">
                             <rect key="frame" x="5" y="0.0" width="120" height="50"/>
@@ -92,22 +92,20 @@
                     </customSpacing>
                 </stackView>
                 <stackView identifier="optionsstack" distribution="fill" orientation="horizontal" alignment="top" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ers-BA-ciA" userLabel="PTN Options Stack">
-                    <rect key="frame" x="0.0" y="4" width="544" height="33"/>
+                    <rect key="frame" x="14" y="4" width="544" height="33"/>
                     <subviews>
                         <button identifier="breakbutton" verticalHuggingPriority="850" translatesAutoresizingMaskIntoConstraints="NO" id="iu6-dS-Gze">
-                            <rect key="frame" x="5" y="13" width="55" height="15"/>
-                            <buttonCell key="cell" type="roundRect" title="Break" bezelStyle="roundedRect" alignment="left" controlSize="mini" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="kyc-yB-AnY">
+                            <rect key="frame" x="5" y="13" width="69" height="15"/>
+                            <buttonCell key="cell" type="roundRect" title="Skip session" bezelStyle="roundedRect" alignment="left" controlSize="mini" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="kyc-yB-AnY">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="label" size="9"/>
-                                <string key="keyEquivalent">B</string>
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </buttonCell>
                             <connections>
-                                <action selector="breakButtonPressed:" target="-2" id="fEH-mX-QfS"/>
+                                <action selector="skipButtonPressed:" target="-2" id="Q1F-EG-rGW"/>
                             </connections>
                         </button>
                         <customView identifier="spacer" translatesAutoresizingMaskIntoConstraints="NO" id="6Yy-Wb-eC7" userLabel="Spacer">
-                            <rect key="frame" x="60" y="14" width="339" height="14"/>
+                            <rect key="frame" x="74" y="14" width="325" height="14"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="1" id="CiB-9s-9gX"/>
                             </constraints>

--- a/whatdidUITests/PtnViewControllerTest.swift
+++ b/whatdidUITests/PtnViewControllerTest.swift
@@ -254,6 +254,30 @@ class PtnViewControllerTest: XCTestCase {
                 checkLongSessionPrompt(exists: true)
             }
         }
+        group("Skip session button") {
+            let ptn = findPtn()
+            group("Clear out previous entries") {
+                handleLongSessionPrompt(.continueWithCurrentSession)
+                ptn.entriesHook.deleteText(andReplaceWith: "\r")
+            }
+            group("Skip a session") {
+                setTimeUtc(d: 1, h: 6, m: 10)
+                ptn.window.buttons["Skip session"].click()
+                waitForTransition(of: .ptn, toIsVisible: false)
+            }
+            group("Make an entry") {
+                setTimeUtc(d: 1, h: 6, m: 15)
+                clickStatusMenu() // open the menu
+                ptn.pcombo.textField.deleteText(andReplaceWith: "One\tTwo\tThree\r")
+            }
+            group("Validate") {
+                clickStatusMenu()
+                let entries = FlatEntry.deserialize(from: ptn.entriesHook.stringValue)
+                XCTAssertEqual(
+                    [FlatEntry(from: date(d: 1, h: 6, m: 10), to: date(d: 1, h: 6, m: 15), project: "One", task: "Two", notes: "Three")],
+                    entries)
+            }
+        }
     }
     
     func testAutoComplete() {


### PR DESCRIPTION
Removes the break button, so that now you have to manually enter breaks.
Instead, there's a "skip sesion" button. This resolves #66.