### PR TITLE
change how we handle the tolerance

### DIFF
--- a/whatdid/scheduling/SystemClockScheduler.swift
+++ b/whatdid/scheduling/SystemClockScheduler.swift
@@ -3,7 +3,7 @@
 import Cocoa
 
 class SystemClockScheduler: Scheduler {
-    static let TOLERANCE_SECONDS : TimeInterval = 30
+    static let TOLERANCE_SECONDS : TimeInterval = 60
     
     var now: Date {
         return Date()
@@ -14,10 +14,8 @@ class SystemClockScheduler: Scheduler {
     }
     
     func schedule(at date: Date, _ block: @escaping () -> Void) -> ScheduledTask {
-        let tolerence = SystemClockScheduler.TOLERANCE_SECONDS * 2
-        let adjustedDate = date.addingTimeInterval(-tolerence)
-        let timer = Timer(fire: adjustedDate, interval: 0, repeats: false, block: {_ in block()})
-        timer.tolerance = tolerence
+        let timer = Timer(fire: date, interval: 0, repeats: false, block: {_ in block()})
+        timer.tolerance = SystemClockScheduler.TOLERANCE_SECONDS
         RunLoop.current.add(timer, forMode: .default)
         return TimerBasedScheduledTask(timer: timer)
     }

--- a/whatdid/util/TimeUtil.swift
+++ b/whatdid/util/TimeUtil.swift
@@ -43,7 +43,8 @@ class TimeUtil {
     }
     
     static func dateForTime(_ direction: TimeDirection, hh: Int, mm: Int, excludeWeekends: Bool = false, assumingNow: Date? = nil, withTimeZone tz: TimeZone? = nil) -> Date {
-        let now = assumingNow ?? DefaultScheduler.instance.now
+        let now = assumingNow ??
+            DefaultScheduler.instance.now.addingTimeInterval(TimeInterval(direction.timeDelta))
         var cal = Calendar.current
         cal.timeZone = tz ?? DefaultScheduler.instance.timeZone
         var result = cal.date(bySettingHour: hh, minute: mm, second: 00, of: now)
@@ -61,7 +62,7 @@ class TimeUtil {
             }
         }
         while excludeWeekends, let actualResult = result, cal.isDateInWeekend(actualResult) {
-            result = cal.date(byAdding: .day, value: direction.dayDelta, to: actualResult)
+            result = cal.date(byAdding: .day, value: direction.timeDelta, to: actualResult)
         }
         return result!
     }
@@ -121,7 +122,7 @@ class TimeUtil {
         case previous
         case next
         
-        fileprivate var dayDelta: Int {
+        fileprivate var timeDelta: Int {
             switch self {
             case .previous:
                 return -1


### PR DESCRIPTION
Only have it look forward, not +/-. Otherwise, you can get a situation
where the daily report pops up at 6:30pm +/- 30s, so it actually pops up
at 6:29:30. Then you dismiss it at (say) 6:29:40, and it schedules the
next one at that same 6:30 (ie, in 20 seconds) +/- 30s, and so pops up
again instantly.

This change resolves #130.