### PR TITLE
esc closes window from autocomplete fields

### DIFF
--- a/whatdidUITests/AutocompleteFieldHelper.swift
+++ b/whatdidUITests/AutocompleteFieldHelper.swift
@@ -15,12 +15,26 @@ struct AutocompleteFieldHelper {
         return element.children(matching: .popUpButton).element
     }
     
-    /// The options pane, or `nil` if it is not open
+    /// The options pane, or fail if it is not open
     var optionsScroll: XCUIElement {
         return XCTestCase.group("FieldHelper: fetch optionsScroll") {
             let allScrolls = element.children(matching: .scrollView).allElementsBoundByIndex
             XCTAssertEqual(1, allScrolls.count, "Expected exactly one options pane")
             return allScrolls[0]
+        }
+    }
+    
+    var optionsScrollIsOpen: Bool {
+        return XCTestCase.group("FieldHelper: fetch optionsScroll") {
+            switch element.children(matching: .scrollView).allElementsBoundByIndex.count {
+            case 0:
+                return false
+            case 1:
+                return true
+            default:
+                XCTFail("expected 0 or 1 optionsScrolls")
+                return false
+            }
         }
     }
     

--- a/whatdidUITests/PtnViewControllerTest.swift
+++ b/whatdidUITests/PtnViewControllerTest.swift
@@ -649,10 +649,27 @@ class PtnViewControllerTest: XCTestCase {
             XCTAssertTrue(ptn.window.textFields["nfield"].hasFocus)
         }
         group("escape key within notes") {
+            XCTAssertTrue(ptn.window.textFields["nfield"].hasFocus)
             ptn.window.typeKey(.escape, modifierFlags: [])
-            XCTAssertFalse(ptn.window.isVisible)
-            clickStatusMenu()
-            waitForTransition(of: .ptn, toIsVisible: true)
+            waitForTransition(of: .ptn, toIsVisible: false)
+        }
+        group("escape key within project combo") {
+            group("Open PTN") {
+                XCTAssertFalse(ptn.window.isVisible)
+                clickStatusMenu()
+                waitForTransition(of: .ptn, toIsVisible: true)
+            }
+            group("Escape key #1: hide options") {
+                XCTAssertTrue(ptn.pcombo.textField.hasFocus)
+                XCTAssertTrue(ptn.pcombo.optionsScroll.isVisible)
+                ptn.window.typeKey(.escape, modifierFlags: [])
+                XCTAssertFalse(ptn.pcombo.optionsScrollIsOpen)
+            }
+            group("Escape key #2: hide window") {
+                XCTAssertTrue(ptn.window.isVisible)
+                ptn.window.typeKey(.escape, modifierFlags: [])
+                waitForTransition(of: .ptn, toIsVisible: false)
+            }
         }
     }
     


### PR DESCRIPTION
The first time you press esc, it hides the options pane (but keeps focus
in the field). The second time, it acts like esc in a normal text field,
which for us means it closes the window.

Resolves #95 