### PR TITLE
add tabs to preferences pane

### DIFF
--- a/whatdid.xcodeproj/project.pbxproj
+++ b/whatdid.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		7EE0E74624E8899E002D03F8 /* AutoCompletingField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE0E74524E8899E002D03F8 /* AutoCompletingField.swift */; };
 		7EE0E74824EA1ECD002D03F8 /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE0E74724EA1ECD002D03F8 /* String+Helpers.swift */; };
 		7EE0E74A24EA22E7002D03F8 /* NSView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE0E74924EA22E7002D03F8 /* NSView+Helpers.swift */; };
+		7EE250BB2515B8FE0067C5E9 /* PrefsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE250B92515B8FE0067C5E9 /* PrefsViewController.swift */; };
+		7EE250BC2515B8FE0067C5E9 /* PrefsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7EE250BA2515B8FE0067C5E9 /* PrefsViewController.xib */; };
 		7EE4E39624E24A3F00552AAF /* ManualTickSchedulerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE4E39524E24A3F00552AAF /* ManualTickSchedulerWindow.swift */; };
 		7EE4E39824E2523F00552AAF /* SystemClockScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE4E39724E2523F00552AAF /* SystemClockScheduler.swift */; };
 		7EE4E39A24E25C0200552AAF /* DefaultScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE4E39924E25C0200552AAF /* DefaultScheduler.swift */; };
@@ -148,6 +150,8 @@
 		7EE0E74524E8899E002D03F8 /* AutoCompletingField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoCompletingField.swift; sourceTree = "<group>"; };
 		7EE0E74724EA1ECD002D03F8 /* String+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
 		7EE0E74924EA22E7002D03F8 /* NSView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSView+Helpers.swift"; sourceTree = "<group>"; };
+		7EE250B92515B8FE0067C5E9 /* PrefsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefsViewController.swift; sourceTree = "<group>"; };
+		7EE250BA2515B8FE0067C5E9 /* PrefsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PrefsViewController.xib; sourceTree = "<group>"; };
 		7EE4E39524E24A3F00552AAF /* ManualTickSchedulerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualTickSchedulerWindow.swift; sourceTree = "<group>"; };
 		7EE4E39724E2523F00552AAF /* SystemClockScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemClockScheduler.swift; sourceTree = "<group>"; };
 		7EE4E39924E25C0200552AAF /* DefaultScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultScheduler.swift; sourceTree = "<group>"; };
@@ -263,6 +267,8 @@
 				7EFEE80123B16EA6002928A2 /* PtnViewController.swift */,
 				7EA6E22724BD6C5F004B9297 /* PtnViewController.xib */,
 				7E7C385324DF3A0300CFF3E7 /* PtnViewController+UIHook.swift */,
+				7EE250B92515B8FE0067C5E9 /* PrefsViewController.swift */,
+				7EE250BA2515B8FE0067C5E9 /* PrefsViewController.xib */,
 				7EAC528A24CFC94700A13B72 /* boilerplate */,
 				7E37A27524BFF73E005BA1DF /* model */,
 				7EF8579F24E241E800867832 /* scheduling */,
@@ -484,6 +490,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7E07C3B924D121770007FD23 /* DayEndReportController.xib in Resources */,
+				7EE250BC2515B8FE0067C5E9 /* PrefsViewController.xib in Resources */,
 				7E8C04E023714F0800A0C3A6 /* Assets.xcassets in Resources */,
 				7EA6E22824BD6C5F004B9297 /* PtnViewController.xib in Resources */,
 				7EA6E22624BD61FD004B9297 /* MainMenu.xib in Resources */,
@@ -546,6 +553,7 @@
 				7EE0E74A24EA22E7002D03F8 /* NSView+Helpers.swift in Sources */,
 				7EDA369324D60FCD00F5E368 /* ButtonWithClosure.swift in Sources */,
 				7E7C385424DF3A0300CFF3E7 /* PtnViewController+UIHook.swift in Sources */,
+				7EE250BB2515B8FE0067C5E9 /* PrefsViewController.swift in Sources */,
 				7E37A29B24C0293E005BA1DF /* Entry+CoreDataProperties.swift in Sources */,
 				7ECAF0DF250D75B70004647E /* WhatdidTextField.swift in Sources */,
 				7EE4E39624E24A3F00552AAF /* ManualTickSchedulerWindow.swift in Sources */,

--- a/whatdid/PrefsViewController.swift
+++ b/whatdid/PrefsViewController.swift
@@ -2,7 +2,7 @@
 
 import Cocoa
 
-class PrefsViewController: NSViewController {
+class PrefsViewController: NSViewController, NSToolbarDelegate {
     @IBOutlet private var outerVStackWidth: NSLayoutConstraint!
     @IBOutlet var outerVStackMinHeight: NSLayoutConstraint!
     private var desiredWidth: CGFloat = 0
@@ -43,6 +43,26 @@ class PrefsViewController: NSViewController {
         if !mainTabs.tabViewItems.isEmpty {
             mainTabs.selectTabViewItem(at: 0) // TODO save which one is selected
         }
+    }
+    
+    func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        return mainTabs.tabViewItems.map({tab in NSToolbarItem.Identifier(rawValue: tab.label)})
+    }
+    
+    func toolbar(_ toolbar: NSToolbar, itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier, willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
+        print("asking for toolbar: \(itemIdentifier.rawValue)")
+        let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+        item.image = NSImage(named: NSImage.infoName)
+        item.label = itemIdentifier.rawValue
+        return item
+    }
+    
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        return toolbarAllowedItemIdentifiers(toolbar)
+    }
+    
+    func toolbarSelectableItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        return toolbarDefaultItemIdentifiers(toolbar)
     }
     
     func setSize(width: CGFloat, minHeight: CGFloat) {

--- a/whatdid/PrefsViewController.swift
+++ b/whatdid/PrefsViewController.swift
@@ -19,11 +19,17 @@ class PrefsViewController: NSViewController {
         tabButtonsStack.wantsLayer = true
         tabButtonsStack.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
         
+        tabButtonsStack.subviews.forEach {$0.removeFromSuperview()}
         for tab in mainTabs.tabViewItems {
             let text = tab.label
             let button = ButtonWithClosure(label: text) {_ in
                 print("hello from \(text)")
             }
+            button.bezelStyle = .smallSquare
+            button.image = tab.value(forKey: "image") as? NSImage
+            button.imagePosition = .imageLeading
+            button.imageScaling = .scaleProportionallyDown
+            button.setButtonType(.pushOnPushOff)
             tabButtonsStack.addArrangedSubview(button)
         }
         tabButtonsStack.addArrangedSubview(NSView()) // trailing spacer

--- a/whatdid/PrefsViewController.swift
+++ b/whatdid/PrefsViewController.swift
@@ -20,19 +20,29 @@ class PrefsViewController: NSViewController {
         tabButtonsStack.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
         
         tabButtonsStack.subviews.forEach {$0.removeFromSuperview()}
-        for tab in mainTabs.tabViewItems {
+        for (i, tab) in mainTabs.tabViewItems.enumerated() {
             let text = tab.label
             let button = ButtonWithClosure(label: text) {_ in
                 print("hello from \(text)")
+                self.mainTabs.selectTabViewItem(at: i)
+                for (otherButtonIdx, subview) in self.tabButtonsStack.arrangedSubviews.enumerated() {
+                    if otherButtonIdx != i {
+                        (subview as? NSButton)?.state = .off
+                    }
+                }
             }
             button.bezelStyle = .smallSquare
             button.image = tab.value(forKey: "image") as? NSImage
             button.imagePosition = .imageLeading
             button.imageScaling = .scaleProportionallyDown
             button.setButtonType(.pushOnPushOff)
+            button.focusRingType = .none
             tabButtonsStack.addArrangedSubview(button)
         }
         tabButtonsStack.addArrangedSubview(NSView()) // trailing spacer
+        if !mainTabs.tabViewItems.isEmpty {
+            mainTabs.selectTabViewItem(at: 0) // TODO save which one is selected
+        }
     }
     
     func setSize(width: CGFloat, minHeight: CGFloat) {

--- a/whatdid/PrefsViewController.swift
+++ b/whatdid/PrefsViewController.swift
@@ -23,7 +23,6 @@ class PrefsViewController: NSViewController {
         for (i, tab) in mainTabs.tabViewItems.enumerated() {
             let text = tab.label
             let button = ButtonWithClosure(label: text) {_ in
-                print("hello from \(text)")
                 self.selectPane(at: i)
             }
             button.bezelStyle = .smallSquare
@@ -32,6 +31,8 @@ class PrefsViewController: NSViewController {
             button.imageScaling = .scaleProportionallyDown
             button.setButtonType(.pushOnPushOff)
             button.focusRingType = .none
+            button.setAccessibilityRole(.button)
+            button.setAccessibilitySubrole(.tabButtonSubrole)
             tabButtonsStack.addArrangedSubview(button)
         }
         tabButtonsStack.addArrangedSubview(NSView()) // trailing spacer

--- a/whatdid/PrefsViewController.swift
+++ b/whatdid/PrefsViewController.swift
@@ -35,6 +35,8 @@ class PrefsViewController: NSViewController {
             tabButtonsStack.addArrangedSubview(button)
         }
         tabButtonsStack.addArrangedSubview(NSView()) // trailing spacer
+        
+        setUpAboutPanel()
     }
     
     override func viewWillAppear() {
@@ -49,7 +51,7 @@ class PrefsViewController: NSViewController {
             (subview as? NSButton)?.state = state
         }
         self.mainTabs.selectTabViewItem(at: index)
-        view.layout()
+        view.layoutSubtreeIfNeeded()
         view.window?.setContentSize(view.fittingSize)
     }
 
@@ -66,13 +68,46 @@ class PrefsViewController: NSViewController {
         endParentSheet(with: .cancel)
     }
     
-    @IBAction func saveButton(_ sender: Any) {
-        endParentSheet(with: .OK)
-    }
-    
     private func endParentSheet(with response: NSApplication.ModalResponse) {
         if let myWindow = view.window, let mySheetParent = myWindow.sheetParent {
             mySheetParent.endSheet(myWindow, returnCode: response)
         }
     }
+    
+    //------------------------------------------------------------------
+    // ABOUT
+    //------------------------------------------------------------------
+    
+    @IBOutlet var shortVersion: NSTextField!
+    @IBOutlet var fullVersion: NSTextField!
+    @IBOutlet var shaVersion: NSButton!
+    
+    private func setUpAboutPanel() {
+        shortVersion.stringValue = shortVersion.stringValue.replacingBracketedPlaceholders(with: [
+            "version": Version.short
+        ])
+        fullVersion.stringValue = fullVersion.stringValue.replacingBracketedPlaceholders(with: [
+            "fullversion": Version.full
+        ])
+        shaVersion.title = shaVersion.title.replacingBracketedPlaceholders(with: [
+            "sha": Version.gitSha
+        ])
+        shaVersion.toolTip = shaVersion.toolTip?.replacingBracketedPlaceholders(with: [
+            "sha": Version.gitSha.replacingOccurrences(of: ".dirty", with: "")
+        ])
+    }
+    
+    //------------------------------------------------------------------
+    // OTHER / COMMON
+    //------------------------------------------------------------------
+    
+    /// turns a button into an <a href>, with the link coming from the button's tooltip. Hacky, but easy. :-)
+    @IBAction func href(_ sender: NSButton) {
+        if let location = sender.toolTip, let url = URL(string: location) {
+            NSWorkspace.shared.open(url)
+        } else {
+            NSLog("invalid href: \(sender.toolTip ?? "<nil>")")
+        }
+    }
+    
 }

--- a/whatdid/PrefsViewController.swift
+++ b/whatdid/PrefsViewController.swift
@@ -1,0 +1,54 @@
+// whatdid?
+
+import Cocoa
+
+class PrefsViewController: NSViewController {
+    @IBOutlet private var outerVStackWidth: NSLayoutConstraint!
+    @IBOutlet var outerVStackMinHeight: NSLayoutConstraint!
+    private var desiredWidth: CGFloat = 0
+    private var minHeight: CGFloat = 0
+    
+    @IBOutlet var tabButtonsStack: NSStackView!
+    @IBOutlet var mainTabs: NSTabView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        outerVStackWidth.constant = desiredWidth
+        outerVStackMinHeight.constant = minHeight
+        
+        tabButtonsStack.wantsLayer = true
+        tabButtonsStack.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        
+        for tab in mainTabs.tabViewItems {
+            let text = tab.label
+            let button = ButtonWithClosure(label: text) {_ in
+                print("hello from \(text)")
+            }
+            tabButtonsStack.addArrangedSubview(button)
+        }
+        tabButtonsStack.addArrangedSubview(NSView()) // trailing spacer
+    }
+    
+    func setSize(width: CGFloat, minHeight: CGFloat) {
+        self.desiredWidth = width
+        self.minHeight = minHeight
+    }
+    
+    @IBAction func quitButton(_ sender: Any) {
+        endParentSheet(with: .stop)
+    }
+    
+    @IBAction func cancelButton(_ sender: Any) {
+        endParentSheet(with: .cancel)
+    }
+    
+    @IBAction func saveButton(_ sender: Any) {
+        endParentSheet(with: .OK)
+    }
+    
+    private func endParentSheet(with response: NSApplication.ModalResponse) {
+        if let myWindow = view.window, let mySheetParent = myWindow.sheetParent {
+            mySheetParent.endSheet(myWindow, returnCode: response)
+        }
+    }
+}

--- a/whatdid/PrefsViewController.xib
+++ b/whatdid/PrefsViewController.xib
@@ -8,9 +8,12 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PrefsViewController" customModule="whatdid" customModuleProvider="target">
             <connections>
+                <outlet property="fullVersion" destination="3K9-EY-10F" id="TTt-Gz-mxh"/>
                 <outlet property="mainTabs" destination="S38-2I-rYd" id="w8e-74-FHI"/>
                 <outlet property="outerVStackMinHeight" destination="sfZ-rm-XWd" id="HKi-ht-G3J"/>
                 <outlet property="outerVStackWidth" destination="pP3-Nb-iFv" id="WCh-2f-MdV"/>
+                <outlet property="shaVersion" destination="CCA-RA-eto" id="MH7-Sd-b5O"/>
+                <outlet property="shortVersion" destination="WTv-mo-8cX" id="viM-vP-xCV"/>
                 <outlet property="tabButtonsStack" destination="HiW-d6-AUq" id="ecR-r5-3c8"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
@@ -18,13 +21,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="358" height="299"/>
+            <rect key="frame" x="0.0" y="0.0" width="358" height="398"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kp1-1s-z5L" userLabel="Outer VStack">
-                    <rect key="frame" x="4" y="3" width="350" height="293"/>
+                    <rect key="frame" x="4" y="3" width="350" height="392"/>
                     <subviews>
                         <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HiW-d6-AUq" userLabel="Tab Buttons">
-                            <rect key="frame" x="0.0" y="255" width="350" height="38"/>
+                            <rect key="frame" x="0.0" y="354" width="350" height="38"/>
                             <subviews>
                                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kyk-QN-AE9">
                                     <rect key="frame" x="0.0" y="0.0" width="96" height="38"/>
@@ -70,10 +73,10 @@
                             </customSpacing>
                         </stackView>
                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="tah-vZ-4uX">
-                            <rect key="frame" x="0.0" y="252" width="350" height="5"/>
+                            <rect key="frame" x="0.0" y="351" width="350" height="5"/>
                         </box>
                         <tabView controlSize="small" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="S38-2I-rYd">
-                            <rect key="frame" x="0.0" y="112" width="350" height="142"/>
+                            <rect key="frame" x="0.0" y="211" width="350" height="142"/>
                             <tabViewItems>
                                 <tabViewItem label="General" identifier="" id="3Fi-X3-Od3">
                                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="fmt-Cv-gJX">
@@ -111,72 +114,92 @@
                                 </tabViewItem>
                                 <tabViewItem label="About" identifier="" id="NwU-Zn-0aF">
                                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="rMy-Zr-TwQ">
-                                        <rect key="frame" x="0.0" y="0.0" width="350" height="96"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="53"/>
                                         <subviews>
-                                            <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vRX-G9-MoD">
-                                                <rect key="frame" x="0.0" y="0.0" width="110" height="96"/>
+                                            <stackView toolTip="https://github.com/yshavit/whatdid/" distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vRX-G9-MoD" userLabel="About VStack">
+                                                <rect key="frame" x="0.0" y="0.0" width="186" height="53"/>
                                                 <subviews>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WTv-mo-8cX">
-                                                        <rect key="frame" x="-2" y="80" width="114" height="16"/>
-                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="bNY-1U-YZb">
+                                                        <rect key="frame" x="-2" y="37" width="110" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="whatdid {version}" id="bNY-1U-YZb">
                                                             <font key="font" usesAppearanceFont="YES"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YGr-g1-7m4">
-                                                        <rect key="frame" x="-2" y="64" width="114" height="16"/>
-                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="jhi-wn-wJV">
-                                                            <font key="font" usesAppearanceFont="YES"/>
-                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                        </textFieldCell>
-                                                    </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LSS-MH-k7I">
-                                                        <rect key="frame" x="-2" y="48" width="114" height="16"/>
-                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="3pa-5i-bVN">
-                                                            <font key="font" usesAppearanceFont="YES"/>
-                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                        </textFieldCell>
-                                                    </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fya-Zl-jST">
-                                                        <rect key="frame" x="-2" y="32" width="114" height="16"/>
-                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="fGF-Vh-EAg">
-                                                            <font key="font" usesAppearanceFont="YES"/>
-                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                        </textFieldCell>
-                                                    </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NDQ-Wf-5Ms">
-                                                        <rect key="frame" x="-2" y="16" width="114" height="16"/>
-                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="v7m-kX-NrP">
-                                                            <font key="font" usesAppearanceFont="YES"/>
-                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                        </textFieldCell>
-                                                    </textField>
+                                                    <stackView distribution="fill" orientation="horizontal" alignment="baseline" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kmp-b1-hsa" userLabel="GH link">
+                                                        <rect key="frame" x="0.0" y="17" width="186" height="16"/>
+                                                        <subviews>
+                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YGr-g1-7m4">
+                                                                <rect key="frame" x="-2" y="0.0" width="54" height="16"/>
+                                                                <textFieldCell key="cell" lineBreakMode="clipping" title="GitHub: " id="jhi-wn-wJV">
+                                                                    <font key="font" usesAppearanceFont="YES"/>
+                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                            </textField>
+                                                            <button toolTip="https://github.com/yshavit/whatdid/" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Qgx-ZJ-RmN">
+                                                                <rect key="frame" x="50" y="0.0" width="100" height="16"/>
+                                                                <buttonCell key="cell" type="bevel" title="yshavit/whatdid" bezelStyle="rounded" alignment="right" imageScaling="proportionallyDown" inset="2" id="yML-a4-nda">
+                                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                    <font key="font" metaFont="system"/>
+                                                                </buttonCell>
+                                                                <color key="contentTintColor" name="linkColor" catalog="System" colorSpace="catalog"/>
+                                                                <connections>
+                                                                    <action selector="href:" target="-2" id="Tji-BQ-qQR"/>
+                                                                </connections>
+                                                            </button>
+                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="s8a-TO-M4g">
+                                                                <rect key="frame" x="148" y="1" width="13" height="11"/>
+                                                                <textFieldCell key="cell" controlSize="mini" lineBreakMode="clipping" title="@" id="1yw-Aj-iAg">
+                                                                    <font key="font" metaFont="menu" size="9"/>
+                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                            </textField>
+                                                            <button toolTip="https://github.com/yshavit/whatdid/commit/{sha}" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CCA-RA-eto">
+                                                                <rect key="frame" x="159" y="1" width="27" height="11"/>
+                                                                <buttonCell key="cell" type="bevel" title="{sha}" bezelStyle="rounded" alignment="right" controlSize="mini" imageScaling="proportionallyDown" inset="2" id="hMN-3N-viT">
+                                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                    <font key="font" metaFont="menu" size="9"/>
+                                                                </buttonCell>
+                                                                <color key="contentTintColor" name="linkColor" catalog="System" colorSpace="catalog"/>
+                                                                <connections>
+                                                                    <action selector="href:" target="-2" id="ZBY-03-RbO"/>
+                                                                </connections>
+                                                            </button>
+                                                        </subviews>
+                                                        <visibilityPriorities>
+                                                            <integer value="1000"/>
+                                                            <integer value="1000"/>
+                                                            <integer value="1000"/>
+                                                            <integer value="1000"/>
+                                                        </visibilityPriorities>
+                                                        <customSpacing>
+                                                            <real value="3.4028234663852886e+38"/>
+                                                            <real value="3.4028234663852886e+38"/>
+                                                            <real value="3.4028234663852886e+38"/>
+                                                            <real value="3.4028234663852886e+38"/>
+                                                        </customSpacing>
+                                                    </stackView>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3K9-EY-10F">
-                                                        <rect key="frame" x="-2" y="0.0" width="114" height="16"/>
-                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="Lir-2N-fjv">
-                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                        <rect key="frame" x="-2" y="0.0" width="190" height="13"/>
+                                                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="{fullversion}" id="Lir-2N-fjv">
+                                                            <font key="font" metaFont="systemUltraLight" size="10"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
                                                 </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="3K9-EY-10F" firstAttribute="trailing" secondItem="CCA-RA-eto" secondAttribute="trailing" id="pOG-AJ-U4T"/>
+                                                </constraints>
                                                 <visibilityPriorities>
-                                                    <integer value="1000"/>
-                                                    <integer value="1000"/>
-                                                    <integer value="1000"/>
                                                     <integer value="1000"/>
                                                     <integer value="1000"/>
                                                     <integer value="1000"/>
                                                 </visibilityPriorities>
                                                 <customSpacing>
-                                                    <real value="3.4028234663852886e+38"/>
-                                                    <real value="3.4028234663852886e+38"/>
-                                                    <real value="3.4028234663852886e+38"/>
                                                     <real value="3.4028234663852886e+38"/>
                                                     <real value="3.4028234663852886e+38"/>
                                                     <real value="3.4028234663852886e+38"/>
@@ -195,20 +218,26 @@
                                 </tabViewItem>
                             </tabViewItems>
                         </tabView>
-                        <customView verticalHuggingPriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="zD3-zr-z0J" userLabel="spacer">
-                            <rect key="frame" x="0.0" y="16" width="350" height="96"/>
+                        <customView verticalHuggingPriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="zD3-zr-z0J" userLabel="Variable spacer">
+                            <rect key="frame" x="0.0" y="23" width="350" height="188"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" id="eUM-d2-Sw6"/>
                             </constraints>
                         </customView>
-                        <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="999" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YFC-BY-e7h" userLabel="Footer HStack">
+                        <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="S35-fj-6x6">
+                            <rect key="frame" x="0.0" y="14" width="350" height="11"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="7" id="IEO-uz-1pL"/>
+                            </constraints>
+                        </box>
+                        <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="999" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YFC-BY-e7h" userLabel="Footer HStack">
                             <rect key="frame" x="0.0" y="0.0" width="350" height="16"/>
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SsJ-Pl-v9W">
-                                    <rect key="frame" x="0.0" y="-1" width="68" height="17"/>
+                                    <rect key="frame" x="0.0" y="-1" width="72" height="17"/>
                                     <buttonCell key="cell" type="roundRect" title="Quit" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="RFf-SH-J74">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="message" size="11"/>
+                                        <font key="font" metaFont="menu" size="11"/>
                                     </buttonCell>
                                     <connections>
                                         <action selector="quitButton:" target="-2" id="NFs-i8-kKH"/>
@@ -219,10 +248,10 @@
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 </customView>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Spf-a6-7Zd">
-                                    <rect key="frame" x="256" y="-1" width="50" height="17"/>
-                                    <buttonCell key="cell" type="roundRect" title="Cancel" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="tch-2Y-0P2">
+                                    <rect key="frame" x="252" y="-1" width="98" height="17"/>
+                                    <buttonCell key="cell" type="roundRect" title="Done" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="tch-2Y-0P2">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="message" size="11"/>
+                                        <font key="font" metaFont="menu" size="11"/>
                                         <string key="keyEquivalent" base64-UTF8="YES">
 Gw
 </string>
@@ -231,17 +260,8 @@ Gw
                                         <action selector="cancelButton:" target="-2" id="eQn-tF-swp"/>
                                     </connections>
                                 </button>
-                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qtq-lg-Tz8">
-                                    <rect key="frame" x="310" y="-1" width="40" height="17"/>
-                                    <buttonCell key="cell" type="roundRect" title="Save" bezelStyle="roundedRect" alignment="center" controlSize="small" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="aTP-hK-K09">
-                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="message" size="11"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <action selector="saveButton:" target="-2" id="GrO-bg-7jb"/>
-                                    </connections>
-                                </button>
                             </subviews>
+                            <edgeInsets key="edgeInsets" left="0.0" right="0.0" top="4" bottom="0.0"/>
                             <constraints>
                                 <constraint firstItem="4vE-b6-xfr" firstAttribute="height" secondItem="SsJ-Pl-v9W" secondAttribute="height" id="ZeH-q4-TeG"/>
                             </constraints>
@@ -249,10 +269,8 @@ Gw
                                 <integer value="1000"/>
                                 <integer value="1000"/>
                                 <integer value="1000"/>
-                                <integer value="1000"/>
                             </visibilityPriorities>
                             <customSpacing>
-                                <real value="3.4028234663852886e+38"/>
                                 <real value="3.4028234663852886e+38"/>
                                 <real value="3.4028234663852886e+38"/>
                                 <real value="3.4028234663852886e+38"/>
@@ -274,8 +292,10 @@ Gw
                         <integer value="1000"/>
                         <integer value="1000"/>
                         <integer value="1000"/>
+                        <integer value="1000"/>
                     </visibilityPriorities>
                     <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
@@ -290,7 +310,7 @@ Gw
                 <constraint firstItem="kp1-1s-z5L" firstAttribute="height" secondItem="Hz6-mo-xeY" secondAttribute="height" constant="-6" id="rEw-1M-Awp"/>
                 <constraint firstItem="kp1-1s-z5L" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="3" id="yyn-SO-OvE"/>
             </constraints>
-            <point key="canvasLocation" x="139" y="53"/>
+            <point key="canvasLocation" x="139" y="52.5"/>
         </customView>
     </objects>
     <resources>

--- a/whatdid/PrefsViewController.xib
+++ b/whatdid/PrefsViewController.xib
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.3"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="PrefsViewController" customModule="whatdid" customModuleProvider="target">
+            <connections>
+                <outlet property="mainTabs" destination="S38-2I-rYd" id="w8e-74-FHI"/>
+                <outlet property="outerVStackMinHeight" destination="sfZ-rm-XWd" id="HKi-ht-G3J"/>
+                <outlet property="outerVStackWidth" destination="pP3-Nb-iFv" id="WCh-2f-MdV"/>
+                <outlet property="tabButtonsStack" destination="HiW-d6-AUq" id="ecR-r5-3c8"/>
+                <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
+            <rect key="frame" x="0.0" y="0.0" width="350" height="254"/>
+            <subviews>
+                <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kp1-1s-z5L" userLabel="Outer VStack">
+                    <rect key="frame" x="0.0" y="0.0" width="350" height="254"/>
+                    <subviews>
+                        <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HiW-d6-AUq" userLabel="Tab Buttons">
+                            <rect key="frame" x="0.0" y="158" width="350" height="96"/>
+                            <subviews>
+                                <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kyk-QN-AE9">
+                                    <rect key="frame" x="0.0" y="73" width="104" height="23"/>
+                                    <buttonCell key="cell" type="roundTextured" title="General" bezelStyle="texturedRounded" image="NSAdvanced" imagePosition="above" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Tbm-ds-WlL">
+                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                </button>
+                                <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yIq-Xp-hCi">
+                                    <rect key="frame" x="102" y="68" width="110" height="32"/>
+                                    <buttonCell key="cell" type="push" title="Pref Pane 2" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="vyq-sQ-Ukh">
+                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                </button>
+                                <customView verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" id="DZT-CR-EY2">
+                                    <rect key="frame" x="210" y="75" width="140" height="21"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                </customView>
+                            </subviews>
+                            <visibilityPriorities>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                            </visibilityPriorities>
+                            <customSpacing>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                            </customSpacing>
+                        </stackView>
+                        <tabView controlSize="small" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="S38-2I-rYd">
+                            <rect key="frame" x="0.0" y="16" width="350" height="142"/>
+                            <tabViewItems>
+                                <tabViewItem label="General" identifier="" id="3Fi-X3-Od3">
+                                    <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="fmt-Cv-gJX">
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="142"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    </view>
+                                </tabViewItem>
+                                <tabViewItem label="About" identifier="" id="NwU-Zn-0aF">
+                                    <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="rMy-Zr-TwQ">
+                                        <rect key="frame" x="10" y="33" width="344" height="20"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    </view>
+                                </tabViewItem>
+                            </tabViewItems>
+                        </tabView>
+                        <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="999" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YFC-BY-e7h" userLabel="Footer HStack">
+                            <rect key="frame" x="0.0" y="0.0" width="350" height="16"/>
+                            <subviews>
+                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SsJ-Pl-v9W">
+                                    <rect key="frame" x="0.0" y="-1" width="68" height="17"/>
+                                    <buttonCell key="cell" type="roundRect" title="Quit" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="RFf-SH-J74">
+                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                        <font key="font" metaFont="menu" size="11"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="quitButton:" target="-2" id="NFs-i8-kKH"/>
+                                    </connections>
+                                </button>
+                                <customView id="4vE-b6-xfr" userLabel="Spacer">
+                                    <rect key="frame" x="72" y="0.0" width="180" height="16"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                </customView>
+                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Spf-a6-7Zd">
+                                    <rect key="frame" x="256" y="-1" width="50" height="17"/>
+                                    <buttonCell key="cell" type="roundRect" title="Cancel" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="tch-2Y-0P2">
+                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                        <font key="font" metaFont="menu" size="11"/>
+                                        <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="cancelButton:" target="-2" id="eQn-tF-swp"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qtq-lg-Tz8">
+                                    <rect key="frame" x="310" y="-1" width="40" height="17"/>
+                                    <buttonCell key="cell" type="roundRect" title="Save" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="aTP-hK-K09">
+                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                        <font key="font" metaFont="menu" size="11"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="saveButton:" target="-2" id="GrO-bg-7jb"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="4vE-b6-xfr" firstAttribute="height" secondItem="SsJ-Pl-v9W" secondAttribute="height" id="ZeH-q4-TeG"/>
+                            </constraints>
+                            <visibilityPriorities>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                            </visibilityPriorities>
+                            <customSpacing>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                            </customSpacing>
+                        </stackView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="YFC-BY-e7h" firstAttribute="width" secondItem="kp1-1s-z5L" secondAttribute="width" id="MDu-hD-MmM"/>
+                        <constraint firstItem="S38-2I-rYd" firstAttribute="width" secondItem="kp1-1s-z5L" secondAttribute="width" id="STZ-NZ-EFK"/>
+                        <constraint firstItem="HiW-d6-AUq" firstAttribute="width" secondItem="kp1-1s-z5L" secondAttribute="width" id="Sui-hp-H2m"/>
+                        <constraint firstAttribute="width" constant="350" id="pP3-Nb-iFv"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="sfZ-rm-XWd"/>
+                    </constraints>
+                    <visibilityPriorities>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                    </visibilityPriorities>
+                    <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                    </customSpacing>
+                </stackView>
+            </subviews>
+            <constraints>
+                <constraint firstItem="kp1-1s-z5L" firstAttribute="width" secondItem="Hz6-mo-xeY" secondAttribute="width" id="4VX-gU-vqS"/>
+                <constraint firstItem="kp1-1s-z5L" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="GqP-vu-mHa"/>
+                <constraint firstItem="kp1-1s-z5L" firstAttribute="height" secondItem="Hz6-mo-xeY" secondAttribute="height" id="rEw-1M-Awp"/>
+                <constraint firstItem="kp1-1s-z5L" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="yyn-SO-OvE"/>
+            </constraints>
+            <point key="canvasLocation" x="139" y="53"/>
+        </customView>
+    </objects>
+    <resources>
+        <image name="NSAdvanced" width="32" height="32"/>
+    </resources>
+</document>

--- a/whatdid/PrefsViewController.xib
+++ b/whatdid/PrefsViewController.xib
@@ -23,29 +23,41 @@
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kp1-1s-z5L" userLabel="Outer VStack">
                     <rect key="frame" x="0.0" y="0.0" width="350" height="254"/>
                     <subviews>
-                        <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HiW-d6-AUq" userLabel="Tab Buttons">
-                            <rect key="frame" x="0.0" y="158" width="350" height="96"/>
+                        <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HiW-d6-AUq" userLabel="Tab Buttons">
+                            <rect key="frame" x="0.0" y="216" width="350" height="38"/>
                             <subviews>
-                                <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kyk-QN-AE9">
-                                    <rect key="frame" x="0.0" y="73" width="104" height="23"/>
-                                    <buttonCell key="cell" type="roundTextured" title="General" bezelStyle="texturedRounded" image="NSAdvanced" imagePosition="above" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Tbm-ds-WlL">
-                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <button horizontalHuggingPriority="750" verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kyk-QN-AE9">
+                                    <rect key="frame" x="0.0" y="0.0" width="96" height="38"/>
+                                    <buttonCell key="cell" type="square" title="General" bezelStyle="shadowlessSquare" image="NSAdvanced" imagePosition="leading" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Tbm-ds-WlL">
+                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                         <font key="font" metaFont="system"/>
                                     </buttonCell>
                                 </button>
-                                <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yIq-Xp-hCi">
-                                    <rect key="frame" x="102" y="68" width="110" height="32"/>
-                                    <buttonCell key="cell" type="push" title="Pref Pane 2" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="vyq-sQ-Ukh">
-                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <button horizontalHuggingPriority="750" verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="b2F-m0-aIW">
+                                    <rect key="frame" x="96" y="0.0" width="99" height="38"/>
+                                    <buttonCell key="cell" type="square" title="Edit Tasks" bezelStyle="shadowlessSquare" image="NSTouchBarComposeTemplate" imagePosition="leading" alignment="center" lineBreakMode="truncatingTail" borderStyle="border" inset="2" id="riH-LG-1AA">
+                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                         <font key="font" metaFont="system"/>
                                     </buttonCell>
                                 </button>
-                                <customView verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" id="DZT-CR-EY2">
-                                    <rect key="frame" x="210" y="75" width="140" height="21"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <button horizontalHuggingPriority="750" verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d25-Kp-7Kc">
+                                    <rect key="frame" x="195" y="0.0" width="85" height="38"/>
+                                    <buttonCell key="cell" type="square" title="About" bezelStyle="shadowlessSquare" image="NSInfo" imagePosition="leading" alignment="center" lineBreakMode="truncatingTail" borderStyle="border" inset="2" id="nQy-nk-Vts">
+                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                </button>
+                                <customView verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="DZT-CR-EY2">
+                                    <rect key="frame" x="280" y="0.0" width="70" height="38"/>
                                 </customView>
                             </subviews>
+                            <constraints>
+                                <constraint firstItem="d25-Kp-7Kc" firstAttribute="height" secondItem="kyk-QN-AE9" secondAttribute="height" placeholder="YES" id="0aw-5z-p4D"/>
+                                <constraint firstItem="b2F-m0-aIW" firstAttribute="height" secondItem="kyk-QN-AE9" secondAttribute="height" placeholder="YES" id="Vwx-We-SjV"/>
+                                <constraint firstItem="kyk-QN-AE9" firstAttribute="height" secondItem="HiW-d6-AUq" secondAttribute="height" placeholder="YES" id="XuA-3T-WDI"/>
+                            </constraints>
                             <visibilityPriorities>
+                                <integer value="1000"/>
                                 <integer value="1000"/>
                                 <integer value="1000"/>
                                 <integer value="1000"/>
@@ -54,47 +66,57 @@
                                 <real value="3.4028234663852886e+38"/>
                                 <real value="3.4028234663852886e+38"/>
                                 <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
                             </customSpacing>
                         </stackView>
+                        <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="tah-vZ-4uX">
+                            <rect key="frame" x="0.0" y="213" width="350" height="5"/>
+                        </box>
                         <tabView controlSize="small" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="S38-2I-rYd">
-                            <rect key="frame" x="0.0" y="16" width="350" height="142"/>
+                            <rect key="frame" x="0.0" y="73" width="350" height="142"/>
                             <tabViewItems>
                                 <tabViewItem label="General" identifier="" id="3Fi-X3-Od3">
                                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="fmt-Cv-gJX">
                                         <rect key="frame" x="0.0" y="0.0" width="350" height="142"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     </view>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="image" keyPath="image" value="NSAdvanced"/>
+                                    </userDefinedRuntimeAttributes>
                                 </tabViewItem>
                                 <tabViewItem label="About" identifier="" id="NwU-Zn-0aF">
                                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="rMy-Zr-TwQ">
-                                        <rect key="frame" x="10" y="33" width="344" height="20"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="142"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     </view>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="image" keyPath="image" value="NSInfo"/>
+                                    </userDefinedRuntimeAttributes>
                                 </tabViewItem>
                             </tabViewItems>
                         </tabView>
                         <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="999" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YFC-BY-e7h" userLabel="Footer HStack">
-                            <rect key="frame" x="0.0" y="0.0" width="350" height="16"/>
+                            <rect key="frame" x="0.0" y="0.0" width="350" height="73"/>
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SsJ-Pl-v9W">
-                                    <rect key="frame" x="0.0" y="-1" width="68" height="17"/>
+                                    <rect key="frame" x="0.0" y="56" width="68" height="17"/>
                                     <buttonCell key="cell" type="roundRect" title="Quit" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="RFf-SH-J74">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="menu" size="11"/>
+                                        <font key="font" metaFont="controlContent" size="11"/>
                                     </buttonCell>
                                     <connections>
                                         <action selector="quitButton:" target="-2" id="NFs-i8-kKH"/>
                                     </connections>
                                 </button>
                                 <customView id="4vE-b6-xfr" userLabel="Spacer">
-                                    <rect key="frame" x="72" y="0.0" width="180" height="16"/>
+                                    <rect key="frame" x="72" y="57" width="180" height="16"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 </customView>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Spf-a6-7Zd">
-                                    <rect key="frame" x="256" y="-1" width="50" height="17"/>
+                                    <rect key="frame" x="256" y="56" width="50" height="17"/>
                                     <buttonCell key="cell" type="roundRect" title="Cancel" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="tch-2Y-0P2">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="menu" size="11"/>
+                                        <font key="font" metaFont="controlContent" size="11"/>
                                         <string key="keyEquivalent" base64-UTF8="YES">
 Gw
 </string>
@@ -104,10 +126,10 @@ Gw
                                     </connections>
                                 </button>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qtq-lg-Tz8">
-                                    <rect key="frame" x="310" y="-1" width="40" height="17"/>
+                                    <rect key="frame" x="310" y="56" width="40" height="17"/>
                                     <buttonCell key="cell" type="roundRect" title="Save" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="aTP-hK-K09">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="menu" size="11"/>
+                                        <font key="font" metaFont="controlContent" size="11"/>
                                     </buttonCell>
                                     <connections>
                                         <action selector="saveButton:" target="-2" id="GrO-bg-7jb"/>
@@ -132,6 +154,7 @@ Gw
                         </stackView>
                     </subviews>
                     <constraints>
+                        <constraint firstItem="tah-vZ-4uX" firstAttribute="width" secondItem="kp1-1s-z5L" secondAttribute="width" id="C80-0A-jyg"/>
                         <constraint firstItem="YFC-BY-e7h" firstAttribute="width" secondItem="kp1-1s-z5L" secondAttribute="width" id="MDu-hD-MmM"/>
                         <constraint firstItem="S38-2I-rYd" firstAttribute="width" secondItem="kp1-1s-z5L" secondAttribute="width" id="STZ-NZ-EFK"/>
                         <constraint firstItem="HiW-d6-AUq" firstAttribute="width" secondItem="kp1-1s-z5L" secondAttribute="width" id="Sui-hp-H2m"/>
@@ -142,8 +165,10 @@ Gw
                         <integer value="1000"/>
                         <integer value="1000"/>
                         <integer value="1000"/>
+                        <integer value="1000"/>
                     </visibilityPriorities>
                     <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
@@ -161,5 +186,7 @@ Gw
     </objects>
     <resources>
         <image name="NSAdvanced" width="32" height="32"/>
+        <image name="NSInfo" width="32" height="32"/>
+        <image name="NSTouchBarComposeTemplate" width="21" height="30"/>
     </resources>
 </document>

--- a/whatdid/PrefsViewController.xib
+++ b/whatdid/PrefsViewController.xib
@@ -18,13 +18,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="358" height="254"/>
+            <rect key="frame" x="0.0" y="0.0" width="358" height="299"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kp1-1s-z5L" userLabel="Outer VStack">
-                    <rect key="frame" x="4" y="3" width="350" height="248"/>
+                    <rect key="frame" x="4" y="3" width="350" height="293"/>
                     <subviews>
                         <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HiW-d6-AUq" userLabel="Tab Buttons">
-                            <rect key="frame" x="0.0" y="210" width="350" height="38"/>
+                            <rect key="frame" x="0.0" y="255" width="350" height="38"/>
                             <subviews>
                                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kyk-QN-AE9">
                                     <rect key="frame" x="0.0" y="0.0" width="96" height="38"/>
@@ -70,26 +70,40 @@
                             </customSpacing>
                         </stackView>
                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="tah-vZ-4uX">
-                            <rect key="frame" x="0.0" y="207" width="350" height="5"/>
+                            <rect key="frame" x="0.0" y="252" width="350" height="5"/>
                         </box>
                         <tabView controlSize="small" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="S38-2I-rYd">
-                            <rect key="frame" x="0.0" y="67" width="350" height="142"/>
+                            <rect key="frame" x="0.0" y="112" width="350" height="142"/>
                             <tabViewItems>
                                 <tabViewItem label="General" identifier="" id="3Fi-X3-Od3">
                                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="fmt-Cv-gJX">
-                                        <rect key="frame" x="0.0" y="0.0" width="350" height="142"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="16"/>
                                         <subviews>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ML9-gR-CKr">
-                                                <rect key="frame" x="123" y="63" width="114" height="16"/>
-                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="65P-cv-hM5">
-                                                    <font key="font" usesAppearanceFont="YES"/>
-                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                </textFieldCell>
-                                            </textField>
+                                            <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ueH-tQ-LbS">
+                                                <rect key="frame" x="0.0" y="0.0" width="110" height="16"/>
+                                                <subviews>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ML9-gR-CKr">
+                                                        <rect key="frame" x="-2" y="0.0" width="114" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="65P-cv-hM5">
+                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                                <visibilityPriorities>
+                                                    <integer value="1000"/>
+                                                </visibilityPriorities>
+                                                <customSpacing>
+                                                    <real value="3.4028234663852886e+38"/>
+                                                </customSpacing>
+                                            </stackView>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="ueH-tQ-LbS" firstAttribute="top" secondItem="fmt-Cv-gJX" secondAttribute="top" id="6qK-J3-Q8u"/>
+                                            <constraint firstItem="ueH-tQ-LbS" firstAttribute="leading" secondItem="fmt-Cv-gJX" secondAttribute="leading" id="JSx-j7-rhX"/>
+                                            <constraint firstItem="ueH-tQ-LbS" firstAttribute="height" secondItem="fmt-Cv-gJX" secondAttribute="height" id="dQO-Oz-Xro"/>
+                                        </constraints>
                                     </view>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="image" keyPath="image" value="NSAdvanced"/>
@@ -97,19 +111,83 @@
                                 </tabViewItem>
                                 <tabViewItem label="About" identifier="" id="NwU-Zn-0aF">
                                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="rMy-Zr-TwQ">
-                                        <rect key="frame" x="0.0" y="0.0" width="350" height="142"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="96"/>
                                         <subviews>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="E2p-zv-QT1">
-                                                <rect key="frame" x="156" y="63" width="104" height="16"/>
-                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                <textFieldCell key="cell" lineBreakMode="clipping" title="Some about text" id="G2X-2x-DpX">
-                                                    <font key="font" usesAppearanceFont="YES"/>
-                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                </textFieldCell>
-                                            </textField>
+                                            <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vRX-G9-MoD">
+                                                <rect key="frame" x="0.0" y="0.0" width="110" height="96"/>
+                                                <subviews>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WTv-mo-8cX">
+                                                        <rect key="frame" x="-2" y="80" width="114" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="bNY-1U-YZb">
+                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YGr-g1-7m4">
+                                                        <rect key="frame" x="-2" y="64" width="114" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="jhi-wn-wJV">
+                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LSS-MH-k7I">
+                                                        <rect key="frame" x="-2" y="48" width="114" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="3pa-5i-bVN">
+                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fya-Zl-jST">
+                                                        <rect key="frame" x="-2" y="32" width="114" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="fGF-Vh-EAg">
+                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NDQ-Wf-5Ms">
+                                                        <rect key="frame" x="-2" y="16" width="114" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="v7m-kX-NrP">
+                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3K9-EY-10F">
+                                                        <rect key="frame" x="-2" y="0.0" width="114" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="Lir-2N-fjv">
+                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                                <visibilityPriorities>
+                                                    <integer value="1000"/>
+                                                    <integer value="1000"/>
+                                                    <integer value="1000"/>
+                                                    <integer value="1000"/>
+                                                    <integer value="1000"/>
+                                                    <integer value="1000"/>
+                                                </visibilityPriorities>
+                                                <customSpacing>
+                                                    <real value="3.4028234663852886e+38"/>
+                                                    <real value="3.4028234663852886e+38"/>
+                                                    <real value="3.4028234663852886e+38"/>
+                                                    <real value="3.4028234663852886e+38"/>
+                                                    <real value="3.4028234663852886e+38"/>
+                                                    <real value="3.4028234663852886e+38"/>
+                                                </customSpacing>
+                                            </stackView>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="vRX-G9-MoD" firstAttribute="leading" secondItem="rMy-Zr-TwQ" secondAttribute="leading" id="1NT-RY-PfB"/>
+                                            <constraint firstItem="vRX-G9-MoD" firstAttribute="top" secondItem="rMy-Zr-TwQ" secondAttribute="top" id="82F-gS-ysP"/>
+                                            <constraint firstItem="vRX-G9-MoD" firstAttribute="height" secondItem="rMy-Zr-TwQ" secondAttribute="height" id="hnU-hO-7No"/>
+                                        </constraints>
                                     </view>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="image" keyPath="image" value="NSInfo"/>
@@ -117,28 +195,34 @@
                                 </tabViewItem>
                             </tabViewItems>
                         </tabView>
+                        <customView verticalHuggingPriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="zD3-zr-z0J" userLabel="spacer">
+                            <rect key="frame" x="0.0" y="16" width="350" height="96"/>
+                            <constraints>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" id="eUM-d2-Sw6"/>
+                            </constraints>
+                        </customView>
                         <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="999" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YFC-BY-e7h" userLabel="Footer HStack">
-                            <rect key="frame" x="0.0" y="0.0" width="350" height="67"/>
+                            <rect key="frame" x="0.0" y="0.0" width="350" height="16"/>
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SsJ-Pl-v9W">
-                                    <rect key="frame" x="0.0" y="50" width="68" height="17"/>
+                                    <rect key="frame" x="0.0" y="-1" width="68" height="17"/>
                                     <buttonCell key="cell" type="roundRect" title="Quit" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="RFf-SH-J74">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="menu" size="11"/>
+                                        <font key="font" metaFont="message" size="11"/>
                                     </buttonCell>
                                     <connections>
                                         <action selector="quitButton:" target="-2" id="NFs-i8-kKH"/>
                                     </connections>
                                 </button>
                                 <customView id="4vE-b6-xfr" userLabel="Spacer">
-                                    <rect key="frame" x="72" y="51" width="180" height="16"/>
+                                    <rect key="frame" x="72" y="0.0" width="180" height="16"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 </customView>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Spf-a6-7Zd">
-                                    <rect key="frame" x="256" y="50" width="50" height="17"/>
+                                    <rect key="frame" x="256" y="-1" width="50" height="17"/>
                                     <buttonCell key="cell" type="roundRect" title="Cancel" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="tch-2Y-0P2">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="menu" size="11"/>
+                                        <font key="font" metaFont="message" size="11"/>
                                         <string key="keyEquivalent" base64-UTF8="YES">
 Gw
 </string>
@@ -148,10 +232,10 @@ Gw
                                     </connections>
                                 </button>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qtq-lg-Tz8">
-                                    <rect key="frame" x="310" y="50" width="40" height="17"/>
+                                    <rect key="frame" x="310" y="-1" width="40" height="17"/>
                                     <buttonCell key="cell" type="roundRect" title="Save" bezelStyle="roundedRect" alignment="center" controlSize="small" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="aTP-hK-K09">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="menu" size="11"/>
+                                        <font key="font" metaFont="message" size="11"/>
                                     </buttonCell>
                                     <connections>
                                         <action selector="saveButton:" target="-2" id="GrO-bg-7jb"/>
@@ -180,6 +264,7 @@ Gw
                         <constraint firstItem="YFC-BY-e7h" firstAttribute="width" secondItem="kp1-1s-z5L" secondAttribute="width" id="MDu-hD-MmM"/>
                         <constraint firstItem="S38-2I-rYd" firstAttribute="width" secondItem="kp1-1s-z5L" secondAttribute="width" id="STZ-NZ-EFK"/>
                         <constraint firstItem="HiW-d6-AUq" firstAttribute="width" secondItem="kp1-1s-z5L" secondAttribute="width" id="Sui-hp-H2m"/>
+                        <constraint firstItem="zD3-zr-z0J" firstAttribute="width" secondItem="kp1-1s-z5L" secondAttribute="width" id="of5-Ab-FLZ"/>
                         <constraint firstAttribute="width" constant="350" id="pP3-Nb-iFv"/>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="sfZ-rm-XWd"/>
                     </constraints>
@@ -188,8 +273,10 @@ Gw
                         <integer value="1000"/>
                         <integer value="1000"/>
                         <integer value="1000"/>
+                        <integer value="1000"/>
                     </visibilityPriorities>
                     <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>

--- a/whatdid/PrefsViewController.xib
+++ b/whatdid/PrefsViewController.xib
@@ -83,11 +83,11 @@
                                         <rect key="frame" x="0.0" y="0.0" width="350" height="16"/>
                                         <subviews>
                                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ueH-tQ-LbS">
-                                                <rect key="frame" x="0.0" y="0.0" width="110" height="16"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="38" height="16"/>
                                                 <subviews>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ML9-gR-CKr">
-                                                        <rect key="frame" x="-2" y="0.0" width="114" height="16"/>
-                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="65P-cv-hM5">
+                                                        <rect key="frame" x="-2" y="0.0" width="42" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="TODO" id="65P-cv-hM5">
                                                             <font key="font" usesAppearanceFont="YES"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/whatdid/PrefsViewController.xib
+++ b/whatdid/PrefsViewController.xib
@@ -18,13 +18,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="350" height="254"/>
+            <rect key="frame" x="0.0" y="0.0" width="358" height="254"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kp1-1s-z5L" userLabel="Outer VStack">
-                    <rect key="frame" x="0.0" y="0.0" width="350" height="254"/>
+                    <rect key="frame" x="4" y="3" width="350" height="248"/>
                     <subviews>
                         <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HiW-d6-AUq" userLabel="Tab Buttons">
-                            <rect key="frame" x="0.0" y="216" width="350" height="38"/>
+                            <rect key="frame" x="0.0" y="210" width="350" height="38"/>
                             <subviews>
                                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kyk-QN-AE9">
                                     <rect key="frame" x="0.0" y="0.0" width="96" height="38"/>
@@ -70,15 +70,26 @@
                             </customSpacing>
                         </stackView>
                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="tah-vZ-4uX">
-                            <rect key="frame" x="0.0" y="213" width="350" height="5"/>
+                            <rect key="frame" x="0.0" y="207" width="350" height="5"/>
                         </box>
                         <tabView controlSize="small" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="S38-2I-rYd">
-                            <rect key="frame" x="0.0" y="73" width="350" height="142"/>
+                            <rect key="frame" x="0.0" y="67" width="350" height="142"/>
                             <tabViewItems>
                                 <tabViewItem label="General" identifier="" id="3Fi-X3-Od3">
                                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="fmt-Cv-gJX">
                                         <rect key="frame" x="0.0" y="0.0" width="350" height="142"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <subviews>
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ML9-gR-CKr">
+                                                <rect key="frame" x="123" y="63" width="114" height="16"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                <textFieldCell key="cell" lineBreakMode="clipping" title="Some general text" id="65P-cv-hM5">
+                                                    <font key="font" usesAppearanceFont="YES"/>
+                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                        </subviews>
                                     </view>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="image" keyPath="image" value="NSAdvanced"/>
@@ -88,6 +99,17 @@
                                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="rMy-Zr-TwQ">
                                         <rect key="frame" x="0.0" y="0.0" width="350" height="142"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <subviews>
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="E2p-zv-QT1">
+                                                <rect key="frame" x="156" y="63" width="104" height="16"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                <textFieldCell key="cell" lineBreakMode="clipping" title="Some about text" id="G2X-2x-DpX">
+                                                    <font key="font" usesAppearanceFont="YES"/>
+                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                        </subviews>
                                     </view>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="image" keyPath="image" value="NSInfo"/>
@@ -96,27 +118,27 @@
                             </tabViewItems>
                         </tabView>
                         <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="999" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YFC-BY-e7h" userLabel="Footer HStack">
-                            <rect key="frame" x="0.0" y="0.0" width="350" height="73"/>
+                            <rect key="frame" x="0.0" y="0.0" width="350" height="67"/>
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SsJ-Pl-v9W">
-                                    <rect key="frame" x="0.0" y="56" width="68" height="17"/>
+                                    <rect key="frame" x="0.0" y="50" width="68" height="17"/>
                                     <buttonCell key="cell" type="roundRect" title="Quit" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="RFf-SH-J74">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="controlContent" size="11"/>
+                                        <font key="font" metaFont="menu" size="11"/>
                                     </buttonCell>
                                     <connections>
                                         <action selector="quitButton:" target="-2" id="NFs-i8-kKH"/>
                                     </connections>
                                 </button>
                                 <customView id="4vE-b6-xfr" userLabel="Spacer">
-                                    <rect key="frame" x="72" y="57" width="180" height="16"/>
+                                    <rect key="frame" x="72" y="51" width="180" height="16"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 </customView>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Spf-a6-7Zd">
-                                    <rect key="frame" x="256" y="56" width="50" height="17"/>
+                                    <rect key="frame" x="256" y="50" width="50" height="17"/>
                                     <buttonCell key="cell" type="roundRect" title="Cancel" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="tch-2Y-0P2">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="controlContent" size="11"/>
+                                        <font key="font" metaFont="menu" size="11"/>
                                         <string key="keyEquivalent" base64-UTF8="YES">
 Gw
 </string>
@@ -126,10 +148,10 @@ Gw
                                     </connections>
                                 </button>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qtq-lg-Tz8">
-                                    <rect key="frame" x="310" y="56" width="40" height="17"/>
-                                    <buttonCell key="cell" type="roundRect" title="Save" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="aTP-hK-K09">
+                                    <rect key="frame" x="310" y="50" width="40" height="17"/>
+                                    <buttonCell key="cell" type="roundRect" title="Save" bezelStyle="roundedRect" alignment="center" controlSize="small" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="aTP-hK-K09">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="controlContent" size="11"/>
+                                        <font key="font" metaFont="menu" size="11"/>
                                     </buttonCell>
                                     <connections>
                                         <action selector="saveButton:" target="-2" id="GrO-bg-7jb"/>
@@ -176,10 +198,10 @@ Gw
                 </stackView>
             </subviews>
             <constraints>
-                <constraint firstItem="kp1-1s-z5L" firstAttribute="width" secondItem="Hz6-mo-xeY" secondAttribute="width" id="4VX-gU-vqS"/>
-                <constraint firstItem="kp1-1s-z5L" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="GqP-vu-mHa"/>
-                <constraint firstItem="kp1-1s-z5L" firstAttribute="height" secondItem="Hz6-mo-xeY" secondAttribute="height" id="rEw-1M-Awp"/>
-                <constraint firstItem="kp1-1s-z5L" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="yyn-SO-OvE"/>
+                <constraint firstItem="kp1-1s-z5L" firstAttribute="width" secondItem="Hz6-mo-xeY" secondAttribute="width" constant="-8" id="4VX-gU-vqS"/>
+                <constraint firstItem="kp1-1s-z5L" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="4" id="GqP-vu-mHa"/>
+                <constraint firstItem="kp1-1s-z5L" firstAttribute="height" secondItem="Hz6-mo-xeY" secondAttribute="height" constant="-6" id="rEw-1M-Awp"/>
+                <constraint firstItem="kp1-1s-z5L" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="3" id="yyn-SO-OvE"/>
             </constraints>
             <point key="canvasLocation" x="139" y="53"/>
         </customView>

--- a/whatdid/PtnViewController.swift
+++ b/whatdid/PtnViewController.swift
@@ -183,44 +183,12 @@ class PtnViewController: NSViewController {
     
     @IBAction func preferenceButtonPressed(_ sender: NSButton) {
         if let viewWindow = view.window {
-            let prefsWindow = NSPanel(contentRect: viewWindow.frame, styleMask: [.titled], backing: .buffered, defer: true)
+            let prefsWindow = NSPanel(contentRect: viewWindow.frame, styleMask: [.hudWindow], backing: .buffered, defer: true)
             prefsWindow.backgroundColor = NSColor.windowBackgroundColor
             
             let prefsViewController = PrefsViewController(nibName: "PrefsViewController", bundle: nil)
             prefsViewController.setSize(width: viewWindow.frame.width, minHeight: viewWindow.frame.height)
             prefsWindow.contentViewController = prefsViewController
-            prefsWindow.toolbar = NSToolbar(identifier: "foo")
-            prefsWindow.toolbar?.delegate = prefsViewController
-            
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .milliseconds(750)) {
-                prefsWindow.showsToolbarButton = true
-                print("window has toolbar? \(prefsWindow.toolbar != nil)")
-            }
-            
-//            let prefsMainStack = NSStackView(orientation: .vertical)
-//            prefsMainStack.edgeInsets = NSEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
-//            prefsMainStack.alignment = .left
-//            prefsWindow.contentView = prefsMainStack
-//
-//            let doneOrCancelRow = NSStackView(orientation: .horizontal)
-//
-//            func button(label: String, enabled: Bool = true, endSheetWith response: NSApplication.ModalResponse) -> NSControl {
-//                let result = ButtonWithClosure(label: label, {_ in
-//                    viewWindow.endSheet(prefsWindow, returnCode: response)
-//                })
-//                result.bezelStyle = .roundRect
-//                result.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
-//                if !enabled {
-//                    result.isEnabled = false
-//                }
-//                return result
-//            }
-//
-//            doneOrCancelRow.addArrangedSubview(button(label: "Quit", endSheetWith: .stop))
-//            doneOrCancelRow.addArrangedSubview(NSView())
-//            doneOrCancelRow.addArrangedSubview(button(label: "Cancel", endSheetWith: .cancel))
-//            doneOrCancelRow.addArrangedSubview(button(label: "Save", enabled: false, endSheetWith: .OK))
-//            prefsMainStack.addArrangedSubview(doneOrCancelRow)
             viewWindow.beginSheet(prefsWindow, completionHandler: {reason in
                 if reason == .stop {
                     NSApp.terminate(self)

--- a/whatdid/PtnViewController.swift
+++ b/whatdid/PtnViewController.swift
@@ -91,6 +91,7 @@ class PtnViewController: NSViewController {
         noteField.stringValue = ""
         setUpSnoozeButton()
         updateHeaderText()
+        grabFocus()
     }
     
     private func setUpSnoozeButton() {

--- a/whatdid/PtnViewController.swift
+++ b/whatdid/PtnViewController.swift
@@ -136,9 +136,10 @@ class PtnViewController: NSViewController {
     
     private func updateHeaderText() {
         let lastEntryDate = AppDelegate.instance.model.lastEntryDate
-        headerText.stringValue = headerText.placeholderString!
-            .replacingOccurrences(of: "{TIME}", with: TimeUtil.formatSuccinctly(date: lastEntryDate))
-            .replacingOccurrences(of: "{DURATION}", with: TimeUtil.daysHoursMinutes(for: timeInterval(since: lastEntryDate)))
+        headerText.stringValue = headerText.placeholderString!.replacingBracketedPlaceholders(with: [
+            "TIME": TimeUtil.formatSuccinctly(date: lastEntryDate),
+            "DURATION": TimeUtil.daysHoursMinutes(for: timeInterval(since: lastEntryDate))
+        ])
     }
     
     @IBAction private func snoozeButtonPressed(_ sender: NSControl) {

--- a/whatdid/PtnViewController.swift
+++ b/whatdid/PtnViewController.swift
@@ -184,13 +184,18 @@ class PtnViewController: NSViewController {
     @IBAction func preferenceButtonPressed(_ sender: NSButton) {
         if let viewWindow = view.window {
             let prefsWindow = NSPanel(contentRect: viewWindow.frame, styleMask: [.titled], backing: .buffered, defer: true)
-//            prefsWindow.toolbar = NSToolbar(identifier: "foo")
-            prefsWindow.toolbar?.insertItem(withItemIdentifier: NSToolbarItem.Identifier(rawValue: "Foo"), at: 0)
             prefsWindow.backgroundColor = NSColor.windowBackgroundColor
             
             let prefsViewController = PrefsViewController(nibName: "PrefsViewController", bundle: nil)
             prefsViewController.setSize(width: viewWindow.frame.width, minHeight: viewWindow.frame.height)
             prefsWindow.contentViewController = prefsViewController
+            prefsWindow.toolbar = NSToolbar(identifier: "foo")
+            prefsWindow.toolbar?.delegate = prefsViewController
+            
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .milliseconds(750)) {
+                prefsWindow.showsToolbarButton = true
+                print("window has toolbar? \(prefsWindow.toolbar != nil)")
+            }
             
 //            let prefsMainStack = NSStackView(orientation: .vertical)
 //            prefsMainStack.edgeInsets = NSEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)

--- a/whatdid/PtnViewController.swift
+++ b/whatdid/PtnViewController.swift
@@ -183,7 +183,9 @@ class PtnViewController: NSViewController {
     
     @IBAction func preferenceButtonPressed(_ sender: NSButton) {
         if let viewWindow = view.window {
-            let prefsWindow = NSWindow(contentRect: viewWindow.frame, styleMask: [], backing: .buffered, defer: true)
+            let prefsWindow = NSPanel(contentRect: viewWindow.frame, styleMask: [.titled], backing: .buffered, defer: true)
+//            prefsWindow.toolbar = NSToolbar(identifier: "foo")
+            prefsWindow.toolbar?.insertItem(withItemIdentifier: NSToolbarItem.Identifier(rawValue: "Foo"), at: 0)
             prefsWindow.backgroundColor = NSColor.windowBackgroundColor
             
             let prefsViewController = PrefsViewController(nibName: "PrefsViewController", bundle: nil)

--- a/whatdid/PtnViewController.swift
+++ b/whatdid/PtnViewController.swift
@@ -185,30 +185,35 @@ class PtnViewController: NSViewController {
         if let viewWindow = view.window {
             let prefsWindow = NSWindow(contentRect: viewWindow.frame, styleMask: [], backing: .buffered, defer: true)
             prefsWindow.backgroundColor = NSColor.windowBackgroundColor
-            let prefsMainStack = NSStackView(orientation: .vertical)
-            prefsMainStack.edgeInsets = NSEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
-            prefsMainStack.alignment = .left
-            prefsWindow.contentView = prefsMainStack
             
-            let doneOrCancelRow = NSStackView(orientation: .horizontal)
+            let prefsViewController = PrefsViewController(nibName: "PrefsViewController", bundle: nil)
+            prefsViewController.setSize(width: viewWindow.frame.width, minHeight: viewWindow.frame.height)
+            prefsWindow.contentViewController = prefsViewController
             
-            func button(label: String, enabled: Bool = true, endSheetWith response: NSApplication.ModalResponse) -> NSControl {
-                let result = ButtonWithClosure(label: label, {_ in
-                    viewWindow.endSheet(prefsWindow, returnCode: response)
-                })
-                result.bezelStyle = .roundRect
-                result.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
-                if !enabled {
-                    result.isEnabled = false
-                }
-                return result
-            }
-            
-            doneOrCancelRow.addArrangedSubview(button(label: "Quit", endSheetWith: .stop))
-            doneOrCancelRow.addArrangedSubview(NSView())
-            doneOrCancelRow.addArrangedSubview(button(label: "Cancel", endSheetWith: .cancel))
-            doneOrCancelRow.addArrangedSubview(button(label: "Save", enabled: false, endSheetWith: .OK))
-            prefsMainStack.addArrangedSubview(doneOrCancelRow)
+//            let prefsMainStack = NSStackView(orientation: .vertical)
+//            prefsMainStack.edgeInsets = NSEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
+//            prefsMainStack.alignment = .left
+//            prefsWindow.contentView = prefsMainStack
+//
+//            let doneOrCancelRow = NSStackView(orientation: .horizontal)
+//
+//            func button(label: String, enabled: Bool = true, endSheetWith response: NSApplication.ModalResponse) -> NSControl {
+//                let result = ButtonWithClosure(label: label, {_ in
+//                    viewWindow.endSheet(prefsWindow, returnCode: response)
+//                })
+//                result.bezelStyle = .roundRect
+//                result.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+//                if !enabled {
+//                    result.isEnabled = false
+//                }
+//                return result
+//            }
+//
+//            doneOrCancelRow.addArrangedSubview(button(label: "Quit", endSheetWith: .stop))
+//            doneOrCancelRow.addArrangedSubview(NSView())
+//            doneOrCancelRow.addArrangedSubview(button(label: "Cancel", endSheetWith: .cancel))
+//            doneOrCancelRow.addArrangedSubview(button(label: "Save", enabled: false, endSheetWith: .OK))
+//            prefsMainStack.addArrangedSubview(doneOrCancelRow)
             viewWindow.beginSheet(prefsWindow, completionHandler: {reason in
                 if reason == .stop {
                     NSApp.terminate(self)

--- a/whatdid/util/String+Helpers.swift
+++ b/whatdid/util/String+Helpers.swift
@@ -6,4 +6,12 @@ extension String {
     func fullNsRange() -> NSRange {
         NSRange(location: 0, length: count)
     }
+    
+    func replacingBracketedPlaceholders(with replacements: [String: String]) -> String {
+        var result = self
+        for (key, value) in replacements {
+            result = result.replacingOccurrences(of: "{\(key)}", with: value)
+        }
+        return result
+    }
 }

--- a/whatdidUITests/PtnViewControllerTest.swift
+++ b/whatdidUITests/PtnViewControllerTest.swift
@@ -103,6 +103,7 @@ class PtnViewControllerTest: XCTestCase {
             assertThat(window: .ptn, isVisible: false)
             setTimeUtc(h: 0, m: 55) // 02:55; enough time for the popup
             waitForTransition(of: .ptn, toIsVisible: true)
+            XCTAssertTrue(findPtn().pcombo.hasFocus)
         }
         group("Header text") {
             XCTAssertEqual(

--- a/whatdidUITests/PtnViewControllerTest.swift
+++ b/whatdidUITests/PtnViewControllerTest.swift
@@ -630,16 +630,24 @@ class PtnViewControllerTest: XCTestCase {
     func testPreferences() {
         let ptn = openPtn()
         let prefsButton = ptn.window.buttons["Preferences"]
+        let prefsSheet = ptn.window.sheets.firstMatch
+        prefsButton.click()
+        group("About") {
+            prefsSheet.tabs["About"].click()
+            // Sanity check: just make sure that the text includes "whatdid {version}".
+            // Note: we'll need to update this whenever we do a version bump.
+            // That seems more explicit and easier to reason about than plumbing the Version class to here
+            XCTAssertTrue(prefsSheet.staticTexts["whatdid 0.1"].firstMatch.isVisible)
+        }
         group("Cancel preferences") {
-            prefsButton.click()
-            wait(for: "prefernces sheet", until: {ptn.window.exists && ptn.window.sheets.count > 0})
-            ptn.window.sheets.firstMatch.buttons["Cancel"].click()
+            wait(for: "preferences sheet", until: {ptn.window.exists && ptn.window.sheets.count > 0})
+            prefsSheet.buttons["Done"].click()
             wait(for: "prefernces sheet", until: {ptn.window.exists && ptn.window.sheets.count == 0})
         }
         group("Quit") {
             prefsButton.click()
             wait(for: "prefernces sheet", until: {ptn.window.exists && ptn.window.sheets.count > 0})
-            ptn.window.sheets.firstMatch.buttons["Quit"].click()
+            prefsSheet.buttons["Quit"].click()
             wait(for: "app to exit", until: {app.state == .notRunning})
        }
     }


### PR DESCRIPTION
This is a precursor to all of our various configuration options
([projects/9](https://github.com/yshavit/whatdid/projects/9)).

I want to organize the preferences pane nicely before I go around adding
too many options.