### PR TITLE
make the global shortcut configurable

### DIFF
--- a/whatdid.xcodeproj/project.pbxproj
+++ b/whatdid.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		7E07C3B824D121770007FD23 /* DayEndReportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E07C3B624D121770007FD23 /* DayEndReportController.swift */; };
 		7E07C3B924D121770007FD23 /* DayEndReportController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7E07C3B724D121770007FD23 /* DayEndReportController.xib */; };
-		7E10088B24CB5FE100D0BAE6 /* HotKey in Frameworks */ = {isa = PBXBuildFile; productRef = 7E10088A24CB5FE100D0BAE6 /* HotKey */; };
 		7E1C2F5124CE43C40070D8CD /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1C2F5024CE43C40070D8CD /* Version.swift */; };
 		7E1F9060250C5CC500992B7F /* TimeZone+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E51DA08250BF5C60088864F /* TimeZone+Helpers.swift */; };
 		7E30B46124C38D91003F3679 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E30B46024C38D91003F3679 /* Atomic.swift */; };
@@ -46,6 +45,8 @@
 		7EA6E22624BD61FD004B9297 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7E8C04E123714F0800A0C3A6 /* MainMenu.xib */; };
 		7EA6E22824BD6C5F004B9297 /* PtnViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7EA6E22724BD6C5F004B9297 /* PtnViewController.xib */; };
 		7EAB5ECD24DA366600E18097 /* TimeUtilTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAB5ECC24DA366600E18097 /* TimeUtilTest.swift */; };
+		7EB7495B251699FD001C7DBC /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 7EB7495A251699FD001C7DBC /* KeyboardShortcuts */; };
+		7EB7495D25169A44001C7DBC /* GlobalShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB7495C25169A44001C7DBC /* GlobalShortcut.swift */; };
 		7EBE61F124DD2739000B2CB3 /* PtnViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBE61F024DD2739000B2CB3 /* PtnViewControllerTest.swift */; };
 		7EBE61F324DD28F2000B2CB3 /* XCUIElement+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBE61F224DD28F2000B2CB3 /* XCUIElement+Helpers.swift */; };
 		7ECAF0DD250C9C110004647E /* NSButton+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECAF0DC250C9C110004647E /* NSButton+Helpers.swift */; };
@@ -136,6 +137,7 @@
 		7EA1DFBE24CA99BF003AD2BC /* MainMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenu.swift; sourceTree = "<group>"; };
 		7EA6E22724BD6C5F004B9297 /* PtnViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PtnViewController.xib; sourceTree = "<group>"; };
 		7EAB5ECC24DA366600E18097 /* TimeUtilTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimeUtilTest.swift; path = whatdidTests/util/TimeUtilTest.swift; sourceTree = SOURCE_ROOT; };
+		7EB7495C25169A44001C7DBC /* GlobalShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalShortcut.swift; sourceTree = "<group>"; };
 		7EBE61F024DD2739000B2CB3 /* PtnViewControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PtnViewControllerTest.swift; sourceTree = "<group>"; };
 		7EBE61F224DD28F2000B2CB3 /* XCUIElement+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Helpers.swift"; sourceTree = "<group>"; };
 		7ECAF0DC250C9C110004647E /* NSButton+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSButton+Helpers.swift"; sourceTree = "<group>"; };
@@ -170,7 +172,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7E10088B24CB5FE100D0BAE6 /* HotKey in Frameworks */,
+				7EB7495B251699FD001C7DBC /* KeyboardShortcuts in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -274,6 +276,7 @@
 				7EF8579F24E241E800867832 /* scheduling */,
 				7E970D6424DA817B00F634AB /* ui_testhook */,
 				7EAC528924CFC90800A13B72 /* util */,
+				7EB7495C25169A44001C7DBC /* GlobalShortcut.swift */,
 			);
 			path = whatdid;
 			sourceTree = "<group>";
@@ -396,7 +399,7 @@
 			);
 			name = whatdid;
 			packageProductDependencies = (
-				7E10088A24CB5FE100D0BAE6 /* HotKey */,
+				7EB7495A251699FD001C7DBC /* KeyboardShortcuts */,
 			);
 			productName = whatdid;
 			productReference = 7E8C04DA23714F0700A0C3A6 /* whatdid.app */;
@@ -471,7 +474,7 @@
 			);
 			mainGroup = 7E8C04D123714F0700A0C3A6;
 			packageReferences = (
-				7E10088924CB5FE100D0BAE6 /* XCRemoteSwiftPackageReference "HotKey" */,
+				7EB74959251699FD001C7DBC /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
 			);
 			productRefGroup = 7E8C04DB23714F0700A0C3A6 /* Products */;
 			projectDirPath = "";
@@ -545,6 +548,7 @@
 				7E37A29524C00266005BA1DF /* Model.swift in Sources */,
 				7E8C04DE23714F0700A0C3A6 /* AppDelegate.swift in Sources */,
 				7EDA368F24D54EA300F5E368 /* FlippedView.swift in Sources */,
+				7EB7495D25169A44001C7DBC /* GlobalShortcut.swift in Sources */,
 				7EF857A324E242AB00867832 /* ManualTickScheduler.swift in Sources */,
 				7E7C384E24DF33A000CFF3E7 /* FlatEntry+Serde.swift in Sources */,
 				7EE4E39824E2523F00552AAF /* SystemClockScheduler.swift in Sources */,
@@ -1052,21 +1056,21 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		7E10088924CB5FE100D0BAE6 /* XCRemoteSwiftPackageReference "HotKey" */ = {
+		7EB74959251699FD001C7DBC /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/soffes/HotKey";
+			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.2;
+				minimumVersion = 0.5.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		7E10088A24CB5FE100D0BAE6 /* HotKey */ = {
+		7EB7495A251699FD001C7DBC /* KeyboardShortcuts */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7E10088924CB5FE100D0BAE6 /* XCRemoteSwiftPackageReference "HotKey" */;
-			productName = HotKey;
+			package = 7EB74959251699FD001C7DBC /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */;
+			productName = KeyboardShortcuts;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/whatdid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/whatdid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "HotKey",
-        "repositoryURL": "https://github.com/soffes/HotKey",
+        "package": "KeyboardShortcuts",
+        "repositoryURL": "https://github.com/sindresorhus/KeyboardShortcuts",
         "state": {
           "branch": null,
-          "revision": "c13662730cb5bc28de4a799854bbb018a90649bf",
-          "version": "0.1.3"
+          "revision": "d97e5e9c62086ffd5fa5fffeadf70b478aa612e2",
+          "version": "0.5.0"
         }
       }
     ]

--- a/whatdid/GlobalShortcut.swift
+++ b/whatdid/GlobalShortcut.swift
@@ -1,0 +1,7 @@
+// whatdid?
+
+import KeyboardShortcuts
+
+extension KeyboardShortcuts.Name {
+    static let grabFocus = Self("grabFocus")
+}

--- a/whatdid/PrefsViewController.swift
+++ b/whatdid/PrefsViewController.swift
@@ -1,6 +1,7 @@
 // whatdid?
 
 import Cocoa
+import KeyboardShortcuts
 
 class PrefsViewController: NSViewController {
     @IBOutlet private var outerVStackWidth: NSLayoutConstraint!
@@ -37,6 +38,7 @@ class PrefsViewController: NSViewController {
         }
         tabButtonsStack.addArrangedSubview(NSView()) // trailing spacer
         
+        setUpGeneralPanel()
         setUpAboutPanel()
     }
     
@@ -74,6 +76,18 @@ class PrefsViewController: NSViewController {
             mySheetParent.endSheet(myWindow, returnCode: response)
         }
     }
+    //------------------------------------------------------------------
+    // General
+    //------------------------------------------------------------------
+    
+    @IBOutlet var globalShortcutHolder: NSView!
+    
+    private func setUpGeneralPanel() {
+        let recorder = KeyboardShortcuts.RecorderCocoa(for: .grabFocus)
+        globalShortcutHolder.addSubview(recorder)
+        recorder.anchorAllSides(to: globalShortcutHolder)
+    }
+    
     
     //------------------------------------------------------------------
     // ABOUT

--- a/whatdid/PrefsViewController.xib
+++ b/whatdid/PrefsViewController.xib
@@ -9,6 +9,7 @@
         <customObject id="-2" userLabel="File's Owner" customClass="PrefsViewController" customModule="whatdid" customModuleProvider="target">
             <connections>
                 <outlet property="fullVersion" destination="3K9-EY-10F" id="TTt-Gz-mxh"/>
+                <outlet property="globalShortcutHolder" destination="cdF-qX-q5Y" id="IHs-3K-vOL"/>
                 <outlet property="mainTabs" destination="S38-2I-rYd" id="w8e-74-FHI"/>
                 <outlet property="outerVStackMinHeight" destination="sfZ-rm-XWd" id="HKi-ht-G3J"/>
                 <outlet property="outerVStackWidth" destination="pP3-Nb-iFv" id="WCh-2f-MdV"/>
@@ -80,32 +81,49 @@
                             <tabViewItems>
                                 <tabViewItem label="General" identifier="" id="3Fi-X3-Od3">
                                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="fmt-Cv-gJX">
-                                        <rect key="frame" x="0.0" y="0.0" width="350" height="16"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="42"/>
                                         <subviews>
-                                            <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ueH-tQ-LbS">
-                                                <rect key="frame" x="0.0" y="0.0" width="38" height="16"/>
-                                                <subviews>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ML9-gR-CKr">
-                                                        <rect key="frame" x="-2" y="0.0" width="42" height="16"/>
-                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="TODO" id="65P-cv-hM5">
-                                                            <font key="font" usesAppearanceFont="YES"/>
-                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                        </textFieldCell>
-                                                    </textField>
-                                                </subviews>
-                                                <visibilityPriorities>
-                                                    <integer value="1000"/>
-                                                </visibilityPriorities>
-                                                <customSpacing>
-                                                    <real value="3.4028234663852886e+38"/>
-                                                </customSpacing>
-                                            </stackView>
+                                            <gridView xPlacement="leading" yPlacement="bottom" rowAlignment="none" translatesAutoresizingMaskIntoConstraints="NO" id="8wI-wf-FiW">
+                                                <rect key="frame" x="0.0" y="0.0" width="200" height="42"/>
+                                                <rows>
+                                                    <gridRow id="ziJ-5D-O0w"/>
+                                                    <gridRow id="Uhr-eN-flM"/>
+                                                    <gridRow yPlacement="center" id="kjr-6r-i1L"/>
+                                                </rows>
+                                                <columns>
+                                                    <gridColumn id="4ur-bR-EOi"/>
+                                                    <gridColumn id="II0-JS-5iC"/>
+                                                </columns>
+                                                <gridCells>
+                                                    <gridCell row="ziJ-5D-O0w" column="4ur-bR-EOi" id="Ejt-6i-Gg7"/>
+                                                    <gridCell row="ziJ-5D-O0w" column="II0-JS-5iC" id="0ZP-7v-mk4"/>
+                                                    <gridCell row="Uhr-eN-flM" column="4ur-bR-EOi" id="jBw-tg-I0b"/>
+                                                    <gridCell row="Uhr-eN-flM" column="II0-JS-5iC" id="lK6-dn-YqO"/>
+                                                    <gridCell row="kjr-6r-i1L" column="4ur-bR-EOi" id="kpc-aH-1bp">
+                                                        <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8o4-sT-8yL">
+                                                            <rect key="frame" x="-2" y="7" width="98" height="16"/>
+                                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Global shortcut" id="aQi-xR-NJg">
+                                                                <font key="font" usesAppearanceFont="YES"/>
+                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
+                                                    </gridCell>
+                                                    <gridCell row="kjr-6r-i1L" column="II0-JS-5iC" id="Zkr-ES-rDM">
+                                                        <customView key="contentView" translatesAutoresizingMaskIntoConstraints="NO" id="cdF-qX-q5Y" userLabel="Global Shortcut Holder">
+                                                            <rect key="frame" x="100" y="0.0" width="100" height="30"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="100" placeholder="YES" id="ceF-V1-7iI"/>
+                                                            </constraints>
+                                                        </customView>
+                                                    </gridCell>
+                                                </gridCells>
+                                            </gridView>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstItem="ueH-tQ-LbS" firstAttribute="top" secondItem="fmt-Cv-gJX" secondAttribute="top" id="6qK-J3-Q8u"/>
-                                            <constraint firstItem="ueH-tQ-LbS" firstAttribute="leading" secondItem="fmt-Cv-gJX" secondAttribute="leading" id="JSx-j7-rhX"/>
-                                            <constraint firstItem="ueH-tQ-LbS" firstAttribute="height" secondItem="fmt-Cv-gJX" secondAttribute="height" id="dQO-Oz-Xro"/>
+                                            <constraint firstItem="8wI-wf-FiW" firstAttribute="height" secondItem="fmt-Cv-gJX" secondAttribute="height" id="Sls-Yh-Z99"/>
+                                            <constraint firstItem="8wI-wf-FiW" firstAttribute="top" secondItem="fmt-Cv-gJX" secondAttribute="top" id="dlV-Xg-9xA"/>
+                                            <constraint firstItem="8wI-wf-FiW" firstAttribute="leading" secondItem="fmt-Cv-gJX" secondAttribute="leading" id="gOR-aE-Rsc"/>
                                         </constraints>
                                     </view>
                                     <userDefinedRuntimeAttributes>
@@ -237,7 +255,7 @@
                                     <rect key="frame" x="0.0" y="-1" width="72" height="17"/>
                                     <buttonCell key="cell" type="roundRect" title="Quit" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="RFf-SH-J74">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="menu" size="11"/>
+                                        <font key="font" metaFont="controlContent" size="11"/>
                                     </buttonCell>
                                     <connections>
                                         <action selector="quitButton:" target="-2" id="NFs-i8-kKH"/>
@@ -251,7 +269,7 @@
                                     <rect key="frame" x="252" y="-1" width="98" height="17"/>
                                     <buttonCell key="cell" type="roundRect" title="Done" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="tch-2Y-0P2">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="menu" size="11"/>
+                                        <font key="font" metaFont="controlContent" size="11"/>
                                         <string key="keyEquivalent" base64-UTF8="YES">
 Gw
 </string>


### PR DESCRIPTION
- Replace HotKey with KeyboardShortcuts, which includes a UI for setting
  new shortcuts.
- UI test mode will save the current prefs, clear them out, and then
  restore them on termination. That will let UI tests work on a clean
  slate, without having to worry about previous preferences or
  interfering with my non-automated-test setup.

This resolves #129 