### PR TITLE
configurable PTN frequency

### DIFF
--- a/whatdid.xcodeproj/project.pbxproj
+++ b/whatdid.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		7E7C384F24DF33A000CFF3E7 /* FlatEntry+Serde.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C384D24DF33A000CFF3E7 /* FlatEntry+Serde.swift */; };
 		7E7C385224DF36D000CFF3E7 /* FlatEntry+SerdeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C385124DF36D000CFF3E7 /* FlatEntry+SerdeTest.swift */; };
 		7E7C385424DF3A0300CFF3E7 /* PtnViewController+UIHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C385324DF3A0300CFF3E7 /* PtnViewController+UIHook.swift */; };
+		7E88F5AA2529AB46002B2F2E /* Int+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E88F5A92529AB46002B2F2E /* Int+Helpers.swift */; };
 		7E8C04DE23714F0700A0C3A6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8C04DD23714F0700A0C3A6 /* AppDelegate.swift */; };
 		7E8C04E023714F0800A0C3A6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E8C04DF23714F0800A0C3A6 /* Assets.xcassets */; };
 		7E8C04FA23714F0800A0C3A6 /* ComponentUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8C04F923714F0800A0C3A6 /* ComponentUITests.swift */; };
@@ -124,6 +125,7 @@
 		7E7C384D24DF33A000CFF3E7 /* FlatEntry+Serde.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FlatEntry+Serde.swift"; sourceTree = "<group>"; };
 		7E7C385124DF36D000CFF3E7 /* FlatEntry+SerdeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FlatEntry+SerdeTest.swift"; sourceTree = "<group>"; };
 		7E7C385324DF3A0300CFF3E7 /* PtnViewController+UIHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PtnViewController+UIHook.swift"; sourceTree = "<group>"; };
+		7E88F5A92529AB46002B2F2E /* Int+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Helpers.swift"; sourceTree = "<group>"; };
 		7E8C04DA23714F0700A0C3A6 /* whatdid.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = whatdid.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E8C04DD23714F0700A0C3A6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7E8C04DF23714F0800A0C3A6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -351,6 +353,7 @@
 				7ECAF0DE250D75B70004647E /* WhatdidTextField.swift */,
 				7EB7495E2516F9C7001C7DBC /* Prefs.swift */,
 				7EB57AA725187548009E85F5 /* NSApperance+Helpers.swift */,
+				7E88F5A92529AB46002B2F2E /* Int+Helpers.swift */,
 			);
 			path = util;
 			sourceTree = "<group>";
@@ -581,6 +584,7 @@
 				7E7B7E6124F2F84000460BC3 /* NSStackView+Helpers.swift in Sources */,
 				7E37A27424BFF676005BA1DF /* Model.xcdatamodeld in Sources */,
 				7EE0E74824EA1ECD002D03F8 /* String+Helpers.swift in Sources */,
+				7E88F5AA2529AB46002B2F2E /* Int+Helpers.swift in Sources */,
 				7E7C384B24DF2E5E00CFF3E7 /* FlatEntry.swift in Sources */,
 				7EE4E39A24E25C0200552AAF /* DefaultScheduler.swift in Sources */,
 				7E37A29124BFFFCB005BA1DF /* Project+CoreDataProperties.swift in Sources */,

--- a/whatdid/MainMenu.swift
+++ b/whatdid/MainMenu.swift
@@ -4,9 +4,6 @@ import Cocoa
 
 class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
     
-    private let POPUP_INTERVAL_MINUTES = 10
-    private let POPUP_INTERVAL_JITTER_MINUTES = 2
-    
     let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     
     private var taskAdditionsPane : PtnViewController!
@@ -73,6 +70,7 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
                 }
             },
             onSchedule: self.schedule)
+        taskAdditionsPane.forceReschedule = opener.forceRescheduleOnClose
     }
     
     @objc private func handleStatusItemPress() {
@@ -162,8 +160,9 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
         let newTask: ScheduledTask
         switch contents {
         case .ptn:
-            let jitterMinutes = Int.random(in: -POPUP_INTERVAL_JITTER_MINUTES...POPUP_INTERVAL_JITTER_MINUTES)
-            let minutes = Double(POPUP_INTERVAL_MINUTES + jitterMinutes)
+            let jitter = Prefs.ptnFrequencyJitterMinutes
+            let jitterMinutes = Int.random(in: -jitter...jitter)
+            let minutes = Double(Prefs.ptnFrequencyMinutes + jitterMinutes)
             newTask = DefaultScheduler.instance.schedule(String(describing: contents), after: minutes * 60.0) {
                 self.opener.open(.ptn, reason: .scheduled)
             }
@@ -174,7 +173,7 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
             }
         }
         if let oldTask = scheduledTasks.updateValue(newTask, forKey: contents) {
-            NSLog("Replacing scheduled task for \(contents)")
+            NSLog("Replaced previously scheduled open for \(contents)")
             oldTask.cancel()
         }
     }

--- a/whatdid/PrefsViewController.swift
+++ b/whatdid/PrefsViewController.swift
@@ -14,6 +14,39 @@ class PrefsViewController: NSViewController {
     @IBOutlet var tabButtonsStack: NSStackView!
     @IBOutlet var mainTabs: NSTabView!
     
+    var ptnScheduleChanged: () -> Void = {}
+    
+    @IBInspectable
+    dynamic var ptnFrequencyMinutes: Int {
+        get {
+            Prefs.ptnFrequencyMinutes
+        } set(value) {
+            let adjusted = value.clipped(to: 5...120)
+            if (value == adjusted) {
+                Prefs.ptnFrequencyMinutes = adjusted
+                let tmp = ptnFrequencyJitterMinutes
+                ptnFrequencyJitterMinutes = tmp // this will auto-clip the value if needed, and call the change handler
+            } else {
+                RunLoop.current.perform { self.ptnFrequencyMinutes = adjusted }
+            }
+        }
+    }
+    
+    @IBInspectable
+    dynamic var ptnFrequencyJitterMinutes: Int {
+        get {
+            Prefs.ptnFrequencyJitterMinutes
+        } set (value) {
+            let adjusted = value.clipped(to: 0...(ptnFrequencyMinutes / 2))
+            if (value == adjusted) {
+                Prefs.ptnFrequencyJitterMinutes = adjusted
+                ptnScheduleChanged()
+            } else {
+                RunLoop.current.perform { self.ptnFrequencyJitterMinutes = adjusted }
+            }
+        }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         outerVStackWidth.constant = desiredWidth

--- a/whatdid/PrefsViewController.xib
+++ b/whatdid/PrefsViewController.xib
@@ -93,8 +93,9 @@
                                         <rect key="frame" x="0.0" y="0.0" width="550" height="148"/>
                                         <subviews>
                                             <gridView xPlacement="leading" yPlacement="center" rowAlignment="none" translatesAutoresizingMaskIntoConstraints="NO" id="8wI-wf-FiW">
-                                                <rect key="frame" x="0.0" y="0.0" width="374" height="97"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="447" height="125"/>
                                                 <rows>
+                                                    <gridRow id="XZL-na-geY"/>
                                                     <gridRow id="ziJ-5D-O0w"/>
                                                     <gridRow id="Uhr-eN-flM"/>
                                                     <gridRow id="OgE-Hg-t3U"/>
@@ -105,6 +106,115 @@
                                                     <gridColumn id="II0-JS-5iC"/>
                                                 </columns>
                                                 <gridCells>
+                                                    <gridCell row="XZL-na-geY" column="4ur-bR-EOi" id="2Qp-R0-Q2j">
+                                                        <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K9K-ak-3e4">
+                                                            <rect key="frame" x="-2" y="106" width="85" height="16"/>
+                                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Prompt every" id="pOY-yU-zkx">
+                                                                <font key="font" usesAppearanceFont="YES"/>
+                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
+                                                    </gridCell>
+                                                    <gridCell row="XZL-na-geY" column="II0-JS-5iC" id="cUr-fb-go0">
+                                                        <stackView key="contentView" distribution="fill" orientation="horizontal" alignment="centerY" spacing="3" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5B5-US-fZ7">
+                                                            <rect key="frame" x="150" y="103" width="297" height="22"/>
+                                                            <subviews>
+                                                                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eP2-Vd-05o">
+                                                                    <rect key="frame" x="0.0" y="1" width="35" height="21"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="35" id="hAW-cg-GJz"/>
+                                                                    </constraints>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" usesSingleLineMode="YES" id="F9p-eX-zQP">
+                                                                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="5eD-n6-YjR"/>
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                    <accessibility description="frequency"/>
+                                                                    <connections>
+                                                                        <binding destination="-2" name="value" keyPath="self.ptnFrequencyMinutes" id="Hbd-ae-wRT">
+                                                                            <dictionary key="options">
+                                                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                                                            </dictionary>
+                                                                        </binding>
+                                                                    </connections>
+                                                                </textField>
+                                                                <stepper identifier="frequencyStepper" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XPS-cX-PyO" userLabel="Frequency">
+                                                                    <rect key="frame" x="35" y="-3" width="19" height="28"/>
+                                                                    <stepperCell key="cell" continuous="YES" alignment="left" maxValue="120" id="Cid-uc-8Tn"/>
+                                                                    <accessibility description="frequency stepper"/>
+                                                                    <connections>
+                                                                        <binding destination="-2" name="value" keyPath="self.ptnFrequencyMinutes" id="nmi-Tl-uKD"/>
+                                                                    </connections>
+                                                                </stepper>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pPW-Zk-CUe">
+                                                                    <rect key="frame" x="52" y="3" width="141" height="16"/>
+                                                                    <textFieldCell key="cell" lineBreakMode="clipping" title="minutes, plus or minus" id="n2c-sX-3nn">
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sbj-WK-0IT" userLabel="Randomness">
+                                                                    <rect key="frame" x="194" y="1" width="35" height="21"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" id="Q5O-Pl-FQs">
+                                                                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="O4S-5f-smy"/>
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                    <accessibility description="frequency randomness"/>
+                                                                    <connections>
+                                                                        <binding destination="-2" name="value" keyPath="self.ptnFrequencyJitterMinutes" id="DyI-90-wqe">
+                                                                            <dictionary key="options">
+                                                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                                            </dictionary>
+                                                                        </binding>
+                                                                    </connections>
+                                                                </textField>
+                                                                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IIK-LL-Vrx">
+                                                                    <rect key="frame" x="229" y="-3" width="19" height="28"/>
+                                                                    <stepperCell key="cell" continuous="YES" alignment="left" maxValue="100" id="cbb-f8-OZ7"/>
+                                                                    <accessibility description="frequency randomness stepper"/>
+                                                                    <connections>
+                                                                        <binding destination="-2" name="value" keyPath="self.ptnFrequencyJitterMinutes" id="Hga-lo-Hqz">
+                                                                            <dictionary key="options">
+                                                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                                            </dictionary>
+                                                                        </binding>
+                                                                    </connections>
+                                                                </stepper>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xw6-5H-ksO">
+                                                                    <rect key="frame" x="246" y="3" width="53" height="16"/>
+                                                                    <textFieldCell key="cell" lineBreakMode="clipping" title="minutes" id="h0g-uE-quG">
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstItem="Sbj-WK-0IT" firstAttribute="width" secondItem="eP2-Vd-05o" secondAttribute="width" id="0Ie-jh-GxC"/>
+                                                            </constraints>
+                                                            <visibilityPriorities>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                            </visibilityPriorities>
+                                                            <customSpacing>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                            </customSpacing>
+                                                        </stackView>
+                                                    </gridCell>
                                                     <gridCell row="ziJ-5D-O0w" column="4ur-bR-EOi" id="Ejt-6i-Gg7">
                                                         <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bVG-ba-4hY">
                                                             <rect key="frame" x="-2" y="77" width="82" height="16"/>
@@ -431,7 +541,7 @@ Gw
                 <constraint firstItem="kp1-1s-z5L" firstAttribute="height" secondItem="Hz6-mo-xeY" secondAttribute="height" constant="-6" id="rEw-1M-Awp"/>
                 <constraint firstItem="kp1-1s-z5L" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="3" id="yyn-SO-OvE"/>
             </constraints>
-            <point key="canvasLocation" x="205" y="-186"/>
+            <point key="canvasLocation" x="205" y="-186.5"/>
         </customView>
     </objects>
     <resources>

--- a/whatdid/PtnViewController.swift
+++ b/whatdid/PtnViewController.swift
@@ -20,7 +20,8 @@ class PtnViewController: NSViewController {
     
     private var optionIsPressed = false
     
-    var closeAction : () -> Void = {}
+    var closeAction: () -> Void = {}
+    var forceReschedule: () -> Void = {}
     
     var scheduler: Scheduler = DefaultScheduler.instance
     
@@ -227,6 +228,7 @@ class PtnViewController: NSViewController {
             
             let prefsViewController = PrefsViewController(nibName: "PrefsViewController", bundle: nil)
             prefsViewController.setSize(width: viewWindow.frame.width, minHeight: viewWindow.frame.height)
+            prefsViewController.ptnScheduleChanged = forceReschedule
             prefsWindow.contentViewController = prefsViewController
             viewWindow.beginSheet(prefsWindow, completionHandler: {reason in
                 if reason == .stop {
@@ -268,7 +270,10 @@ class PtnViewController: NSViewController {
             project: projectField.textField.stringValue,
             task: taskField.textField.stringValue,
             notes: noteField.stringValue,
-            callback: closeAction
+            callback: {
+                self.forceReschedule()
+                self.closeAction()
+            }
         )
     }
     
@@ -288,7 +293,6 @@ class PtnViewController: NSViewController {
     
     private func showNewSessionPrompt() {
         if let window = view.window {
-            
             let sheet = NSWindow(contentRect: window.contentView!.frame, styleMask: [], backing: .buffered, defer: true)
             let mainStack = NSStackView()
             mainStack.orientation = .vertical
@@ -335,6 +339,7 @@ class PtnViewController: NSViewController {
                 }
                 if startNewSession {
                     AppDelegate.instance.model.setLastEntryDateToNow()
+                    self.forceReschedule()
                     self.closeAction()
                 } else {
                     self.grabFocusEvenIfHasSheet()

--- a/whatdid/scheduling/ManualTickScheduler.swift
+++ b/whatdid/scheduling/ManualTickScheduler.swift
@@ -7,6 +7,7 @@ class ManualTickScheduler: Scheduler {
     private var events = [WorkItem]()
     
     @discardableResult func schedule(_ description: String, at date: Date, _ block: @escaping () -> Void) -> ScheduledTask {
+        NSLog("Scheduling \(description) at \(date) (t+\(date.timeIntervalSinceWhatdidNow))")
         if date == _now {
             enqueueAction(block)
             return NoopScheduledItem()

--- a/whatdid/scheduling/ManualTickSchedulerWindow.swift
+++ b/whatdid/scheduling/ManualTickSchedulerWindow.swift
@@ -11,16 +11,17 @@ class ManualTickSchedulerWindow: NSObject, NSTextFieldDelegate {
     private let setter: NSTextField
     private let printUtc: NSTextField
     private let printLocal: NSTextField
-    private let window: NSPanel
+    private let window: NSWindow
     
     init(with scheduler: ManualTickScheduler) {
         self.scheduler = scheduler
-        window = NSPanel(
+        window = NSWindow(
             contentRect: NSRect(x: 0, y: 50, width: 100, height: 50),
             styleMask: [.titled],
             backing: .buffered,
             defer: true,
             screen: nil)
+        window.level = .floating
         window.title = "Mocked Clock"
         
         let stack = NSStackView()

--- a/whatdid/util/Int+Helpers.swift
+++ b/whatdid/util/Int+Helpers.swift
@@ -1,0 +1,14 @@
+// whatdid?
+
+import Cocoa
+
+extension Int {
+    func clipped(to range: ClosedRange<Int>) -> Int {
+        if self < range.lowerBound {
+            return range.lowerBound
+        } else if self > range.upperBound {
+            return range.upperBound
+        }
+        return self
+    }
+}

--- a/whatdid/util/OpenCloseHelper.swift
+++ b/whatdid/util/OpenCloseHelper.swift
@@ -47,6 +47,10 @@ class OpenCloseHelper<T: Hashable & Comparable> {
         }
     }
     
+    func forceRescheduleOnClose() {
+        rescheduleOnClose = true
+    }
+    
     func snooze() {
         isSnoozed = true
     }
@@ -59,19 +63,17 @@ class OpenCloseHelper<T: Hashable & Comparable> {
     func didClose() {
         delegatingScheduler?.close()
         delegatingScheduler = nil
-        guard openItem != nil else {
+        guard let item = openItem else {
             return
         }
+        openItem = nil
         if rescheduleOnClose {
-            let item = openItem!
             rescheduleOnClose = false
-            openItem = nil
             // Schedule even if we're snoozed; if we're still snoozed when the schedule hits, then
             // it'll enqueue itself
             NSLog("OpenCloseHelper: scheduling the next \(item)")
             scheduler(item)
         }
-        openItem = nil
         if !isSnoozed {
             pullFromPending()
         }

--- a/whatdid/util/Prefs.swift
+++ b/whatdid/util/Prefs.swift
@@ -7,6 +7,8 @@ struct Prefs {
     @Pref(key: "dailyReportTime") static var dailyReportTime = HoursAndMinutes(hours: 18, minutes: 00)
     @Pref(key: "dayStartTime") static var dayStartTime = HoursAndMinutes(hours: 09, minutes: 00)
     @Pref(key: "daysIncludeWeekends") static var daysIncludeWeekends = false
+    @Pref(key: "ptnFrequencyMinutes") static var ptnFrequencyMinutes = 12
+    @Pref(key: "ptnFrequencyJitterMinutes") static var ptnFrequencyJitterMinutes = 2
 }
 
 @propertyWrapper

--- a/whatdidTests/util/OpenCloseHelperTest.swift
+++ b/whatdidTests/util/OpenCloseHelperTest.swift
@@ -17,6 +17,22 @@ class OpenCloseHelperTest: XCTestCase {
         XCTAssertEqual([], messages.drain())
     }
     
+    func test_OpenAsManual_WhileClosed_ButForceSchedule() throws {
+        let (och, messages) = createTestObjects()
+        
+        och.open("one", reason: .manual)
+        XCTAssertEqual("one", och.openItem)
+        XCTAssertEqual([Message(shouldOpen: "one", reason: .manual)], messages.drain())
+        
+        och.forceRescheduleOnClose()
+        XCTAssertEqual("one", och.openItem)
+        XCTAssertEqual([], messages.drain())
+        
+        och.didClose()
+        XCTAssertNil(och.openItem)
+        XCTAssertEqual([Message(shouldSchedule: "one")], messages.drain())
+    }
+    
     func test_OpenAsScheduled_WhileClosed() {
         let (och, messages) = createTestObjects()
         

--- a/whatdidUITests/XCUIElement+Helpers.swift
+++ b/whatdidUITests/XCUIElement+Helpers.swift
@@ -71,6 +71,9 @@ extension XCUIElement {
             typeKey("a", modifierFlags: .command)
             typeKey(.delete, modifierFlags:[])
             if let replacementToType = replacement {
+                if !hasFocus {
+                    click()
+                }
                 typeText(replacementToType)
             }
         }


### PR DESCRIPTION
- Fixes #51: Creates a pref for the frequency and jitter, and hooks it
  up to the prefs box. We also reschedule the PTN on close if either the
  frequency or jitter changed.
- Fixes #148: I thought it would be easier to test the frequency and
  jitter work if closing the PTN also resets its timer. That didn't end
  up being the case per se, though the framework is the same (namely,
  the addition of the new `OpenCloseHelper#forceRescheduleOnClose`).