### PR TITLE
attempt to fix wall clock bug

### DIFF
--- a/whatdidTests/scheduling/SystemClockSchedulerTest.swift
+++ b/whatdidTests/scheduling/SystemClockSchedulerTest.swift
@@ -16,6 +16,8 @@ class SystemClockSchedulerTest: XCTestCase {
             XCTAssertEqual(4, checks.count) // sanity check
             
             checks.forEach { $0.start() }
+            sleep(1)
+            checks.forEach { XCTAssertFalse($0.timerFired) }
             checks.filter{$0.shouldGetCanceled}.forEach {check in
                 XCTAssertNotNil(check.scheduledTask, check.description)
                 check.scheduledTask?.cancel()


### PR DESCRIPTION
The daily report sometimes fires later than it should (#133). I think
it's because the computer goes to sleep (ie when I get lunch, etc) and
that throws off the Timer. I think using DispatchWorkItem in the GCD may
fix things, so I'm going give that a try.