### PR TITLE
unify the two build steps

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -3,6 +3,8 @@ name: Build app
 on:
   push: 
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch: {}
 
 jobs:
@@ -20,10 +22,13 @@ jobs:
     - name: Build archive
       run: xcodebuild -scheme whatdid-release build archive -archivePath build/whatdid
     - name: Export archive
+      if: github.ref == 'main'
       run: xcodebuild -exportArchive -archivePath build/whatdid.xcarchive -exportPath build -exportOptionsPlist buildscripts/archive-export.plist
     - name: Create zip
+      if: github.ref == 'main'
       run: (cd build && zip -r whatdid.zip whatdid.app)
     - uses: actions/upload-artifact@v2
+      if: github.ref == 'main'
       with:
         name: whatdid.zip
         path: build/whatdid.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,19 +8,6 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  release-build:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Add MacOS certs
-      # To add the CERTIFICATES_P12 to GH secrets, do:
-      # base64 -w 0 cert.p12
-      run: ./buildscripts/add-osx-cert.sh
-      env:
-        CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
-        CERTIFICATES_P12_PASSWORD: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
-    - name: Build release
-      run: xcodebuild clean build -scheme whatdid-release
   ui-tests:
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
Only have buildapp.yml define the build step, but only have it upload
the export for main.