### PR TITLE
Fix daily report truncation

### DIFF
--- a/whatdid/DayEndReportController.swift
+++ b/whatdid/DayEndReportController.swift
@@ -231,11 +231,11 @@ class DayEndReportController: NSViewController {
             labelStack.orientation = .horizontal
             labelStack.leadingAnchor.constraint(equalTo: enclosing.leadingAnchor).isActive = true
             
-            let projectLabel = NSTextField(labelWithString: label)
+            let projectLabel = WhatdidTextField(wrappingLabelWithString: label)
             projectLabel.font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
             labelStack.addView(projectLabel, in: .leading)
             projectLabel.setAccessibilityLabel("\(scope) \"\(label)\"")
-            let durationLabel = NSTextField(labelWithString: TimeUtil.daysHoursMinutes(for: duration))
+            let durationLabel = WhatdidTextField(wrappingLabelWithString: TimeUtil.daysHoursMinutes(for: duration))
             durationLabel.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
             labelStack.addView(durationLabel, in: .trailing)
             durationLabel.setAccessibilityLabel("\(scope) time for \"\(label)\"")

--- a/whatdid/DayEndReportController.swift
+++ b/whatdid/DayEndReportController.swift
@@ -105,6 +105,7 @@ class DayEndReportController: NSViewController {
                 outOf: allProjectsTotalTime)
             // Tasks box
             let tasksBox = NSBox()
+            tasksBox.useAutoLayout()
             projectVStack.addArrangedSubview(tasksBox)
             tasksBox.setAccessibilityLabel("Tasks for \"\(project.name)\"")
             tasksBox.title = tasksBox.accessibilityLabel()!
@@ -137,35 +138,56 @@ class DayEndReportController: NSViewController {
                 taskHeader.progressBar.leadingAnchor.constraint(equalTo: projectHeader.progressBar.leadingAnchor).isActive = true
                 taskHeader.progressBar.trailingAnchor.constraint(equalTo: projectHeader.progressBar.trailingAnchor).isActive = true
                 previousDetailsBottomAnchor?.constraint(equalTo: taskHeader.topView.topAnchor, constant: -5).isActive = true
-                var details = ""
+                
+                var taskDetailRows = [[NSView]]()
                 task.forEach {entry in
                     if entry.to < todayStart {
                         timeFormatter.dateFormat = "M/d h:mma"
                     }
-                    details += timeFormatter.string(from: entry.from)
-                    details += " - "
+                    var taskTime = timeFormatter.string(from: entry.from)
+                    taskTime += " - "
                     if TimeUtil.sameDay(entry.from, entry.to) {
                         timeFormatter.dateFormat = "h:mma"
                     }
-                    details += timeFormatter.string(from: entry.to)
-                    details += " (" + TimeUtil.daysHoursMinutes(for: entry.duration) + "): "
-                    details += entry.notes ?? "(no notes entered)"
-                    details += "\n"
+                    taskTime += timeFormatter.string(from: entry.to)
+                    taskTime += " (" + TimeUtil.daysHoursMinutes(for: entry.duration) + "):"
+                    
+                    var taskNotes = (entry.notes ?? "").trimmingCharacters(in: .newlines)
+                    if taskNotes.isEmpty {
+                        taskNotes = "(no notes entered)"
+                    }
+                    let fields = [
+                        NSTextField(labelWithString: taskTime),
+                        WhatdidTextField(wrappingLabelWithString: taskNotes),
+                        NSView()
+                    ]
+                    for field in fields {
+                        if let fieldAsText = field as? NSTextField {
+                            fieldAsText.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+                        }
+                    }
+                    
+                    taskDetailRows.append(fields)
                 }
-                let taskDescriptions = details.trimmingCharacters(in: .newlines)
-                let taskDetailsView = NSTextField(labelWithString: taskDescriptions)
-                tasksStack.addArrangedSubview(taskDetailsView)
-                taskDetailsView.setAccessibilityLabel("Details for \(task.name)")
-                taskDetailsView.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
-                taskDetailsView.leadingAnchor.constraint(equalTo: taskHeader.progressBar.leadingAnchor).isActive = true
-                previousDetailsBottomAnchor = taskDetailsView.bottomAnchor
-                // For some reason, especially long (in terms of vertical space) tasks can break the layout when they're hidden:
-                // It shows up as a large vertial blank space. Something something intrinsic size? Anyway, zeroing out the contents
-                // when hidden seems to fix that.
-                let removeTextWhenHidden : (NSButton.StateValue) -> Void = {state in
-                    taskDetailsView.stringValue = state == .off ? "" : taskDescriptions
-                }
-                setUpDisclosureExpansion(disclosure: taskHeader.disclosure, details: taskDetailsView, extraAction: removeTextWhenHidden)
+                
+                
+                let taskDetailsGrid = NSGridView(views: taskDetailRows)
+                taskDetailsGrid.columnSpacing = 4
+                taskDetailsGrid.rowSpacing = 2
+                
+                let taskDetailsGridBox = NSBox()
+                taskDetailsGridBox.useAutoLayout()
+                taskDetailsGridBox.setAccessibilityLabel("Details for \(task.name)")
+                taskDetailsGridBox.title = taskDetailsGridBox.accessibilityLabel()!
+                taskDetailsGridBox.titlePosition = .noTitle
+                taskDetailsGridBox.contentView = taskDetailsGrid
+                tasksStack.addArrangedSubview(taskDetailsGridBox)
+                
+                taskDetailsGridBox.leadingAnchor.constraint(equalTo: taskHeader.progressBar.leadingAnchor).isActive = true
+                taskDetailsGridBox.trailingAnchor.constraint(equalTo: taskHeader.progressBar.trailingAnchor).isActive = true
+                
+                previousDetailsBottomAnchor = taskDetailsGridBox.bottomAnchor
+                setUpDisclosureExpansion(disclosure: taskHeader.disclosure, details: taskDetailsGridBox)
             }
         }
     }
@@ -202,20 +224,14 @@ class DayEndReportController: NSViewController {
         )
     }
     
-    private func setUpDisclosureExpansion(disclosure: ButtonWithClosure, details: NSView, extraAction: ((NSButton.StateValue) -> Void)? = nil) {
+    private func setUpDisclosureExpansion(disclosure: ButtonWithClosure, details: NSView) {
         disclosure.onPress {button in
             self.animate({
                 details.isHidden = button.state == .off
-                if let requestedAction = extraAction {
-                    requestedAction(button.state)
-                }
             })
         }
         
         details.isHidden = disclosure.state == .off
-        if let requestedAction = extraAction {
-            requestedAction(disclosure.state)
-        }
         self.projectsScrollHeight.constant = self.projectsContainer.fittingSize.height
         self.view.layoutSubtreeIfNeeded()
     }

--- a/whatdid/util/WhatdidTextField.swift
+++ b/whatdid/util/WhatdidTextField.swift
@@ -37,10 +37,11 @@ class WhatdidTextField: NSTextField {
         }
         // I'm not sure why we need to shrink the width, but without it, the
         // field wraps one char later than it should.
+        let widthShrink: CGFloat = isEditable ? 4.0 : 0.0
         let tallBounds = NSRect(
             x: bounds.minX,
             y: bounds.minX,
-            width: bounds.width - 4,
+            width: bounds.width - widthShrink,
             height: screen.frame.height)
         let adjustedHeight = cell.cellSize(forBounds: tallBounds)
         return adjustedHeight.height

--- a/whatdidUITests/PtnViewControllerTest.swift
+++ b/whatdidUITests/PtnViewControllerTest.swift
@@ -635,7 +635,7 @@ class PtnViewControllerTest: XCTestCase {
             let projectA = HierarchicalEntryLevel(ancestor: dailyReport, scope: "Project", label: "project a")
             let tasksForA = dailyReport.groups["Tasks for \"project a\""]
             let task1 = HierarchicalEntryLevel(ancestor: tasksForA, scope: "Task", label: "task 1")
-            let task1Details = tasksForA.staticTexts["Details for task 1"]
+            let task1Details = tasksForA.groups["Details for task 1"]
             group("Duration label and indicator") {
                 XCTAssertEqual("30m", projectA.durationLabel.stringValue)
                 if let indicatorBarValue = projectA.indicatorBar.value as? Double {
@@ -668,7 +668,14 @@ class PtnViewControllerTest: XCTestCase {
                 group("Details") {
                     XCTAssertFalse(task1Details.exists)
                     task1.clickDisclosure(until: task1Details, .isVisible)
-                    XCTAssertEqual("1:15am - 1:27am (12m): first thing\n1:40am - 1:45am (5m): back to first", task1Details.stringValue)
+                    XCTAssertEqual(
+                        [
+                            "1:15am - 1:27am (12m):",
+                            "first thing",
+                            "1:40am - 1:45am (5m):",
+                            "back to first",
+                        ],
+                        task1Details.descendants(matching: .staticText).allElementsBoundByIndex.map({$0.stringValue}))
                 }
             }
             group("Task 1 stays expanded if project a folds") {


### PR DESCRIPTION
Before:

![long descriptions are truncated](https://user-images.githubusercontent.com/245940/95687274-88bb2000-0bd0-11eb-8db4-90cc1c8aed75.png)

After:

![long descriptions wrap](https://user-images.githubusercontent.com/245940/95689775-1999f780-0be1-11eb-9ddd-c736982e626f.png)

This fixes #143 (it uses wrapping instead of scrolling, but I like that better).