### PR TITLE
better alculation of the status item's position

### DIFF
--- a/whatdid/MainMenu.swift
+++ b/whatdid/MainMenu.swift
@@ -99,7 +99,7 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate {
         }
         
         window!.setContentSize(window!.contentViewController!.view.fittingSize)
-        if let mainFrame = NSScreen.main?.visibleFrame, let button = statusItem.button {
+        if let mainFrame = statusItem.button?.window?.screen?.visibleFrame, let button = statusItem.button {
             var pos = NSPoint(
                 x: button.window?.frame.minX ?? .zero,
                 y: mainFrame.origin.y + mainFrame.height)


### PR DESCRIPTION
Rather than assuming the main screen, use the button's window's screen.
This attempts to get at #90, though I'm not sure yet if it'll fix it.