### PR TITLE
remove unneeded layout calls

### DIFF
--- a/whatdid/DayEndReportController.swift
+++ b/whatdid/DayEndReportController.swift
@@ -47,6 +47,7 @@ class DayEndReportController: NSViewController {
         entryStartDatePicker.dateValue = thisMorning(assumingNow: now)
         
         updateEntries()
+        resizeAndLayoutIfNeeded()
     }
     
     override func viewWillAppear() {
@@ -160,7 +161,6 @@ class DayEndReportController: NSViewController {
                     } else {
                         self.details(for: task, to: taskDetailsGrid, relativeTo: todayStart)
                     }
-                    taskDetailsGrid.layoutSubtreeIfNeeded()
                 }
             }
         }
@@ -217,8 +217,7 @@ class DayEndReportController: NSViewController {
                 context.allowsImplicitAnimation = true
                 #endif
                 action()
-                self.projectsScrollHeight.constant = self.projectsContainer.fittingSize.height
-                self.view.layoutSubtreeIfNeeded()
+                self.resizeAndLayoutIfNeeded()
                 
                 let newViewBounds = self.view.bounds
                 if let window = self.view.window, let originalWindowFrame = originalWindowFrameOpt {
@@ -236,6 +235,12 @@ class DayEndReportController: NSViewController {
         )
     }
     
+    private func resizeAndLayoutIfNeeded() {
+        view.layoutSubtreeIfNeeded()
+        projectsScrollHeight.constant = projectsContainer.fittingSize.height
+        view.layoutSubtreeIfNeeded()
+    }
+    
     private func setUpDisclosureExpansion(disclosure: ButtonWithClosure, details: NSView, extraAction: ((NSButton.StateValue) -> Void)? = nil) {
         disclosure.onPress {button in
             self.animate({
@@ -250,8 +255,6 @@ class DayEndReportController: NSViewController {
         if let requestedAction = extraAction {
             requestedAction(disclosure.state)
         }
-        self.projectsScrollHeight.constant = self.projectsContainer.fittingSize.height
-        self.view.layoutSubtreeIfNeeded()
     }
     
     struct ExpandableProgressBar {


### PR DESCRIPTION
We call these methods from within `animate()` anyway (which is always
what encloses the methods this diff changes), so we don't need to call
them here. Doing so incurs a big perf hit. With some random data I've
accumulated over the past couple months, setting the daily report's
start to June took ~1.66 seconds before, and now takes about 0.467 s.

This obviates a lot of the need for #146, since the daily report is now
about 4x faster (and we therefore don't benefit as much from a progress
bar while it's going).