### PR TITLE
fix prefs xib

### DIFF
--- a/whatdid/PrefsViewController.xib
+++ b/whatdid/PrefsViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -41,21 +41,21 @@
                                     </buttonCell>
                                 </button>
                                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="b2F-m0-aIW">
-                                    <rect key="frame" x="96" y="0.0" width="99" height="38"/>
+                                    <rect key="frame" x="96" y="0.0" width="95" height="38"/>
                                     <buttonCell key="cell" type="square" title="Edit Tasks" bezelStyle="shadowlessSquare" image="NSTouchBarComposeTemplate" imagePosition="leading" alignment="center" lineBreakMode="truncatingTail" borderStyle="border" inset="2" id="riH-LG-1AA">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                         <font key="font" metaFont="system"/>
                                     </buttonCell>
                                 </button>
                                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d25-Kp-7Kc">
-                                    <rect key="frame" x="195" y="0.0" width="85" height="38"/>
+                                    <rect key="frame" x="191" y="0.0" width="85" height="38"/>
                                     <buttonCell key="cell" type="square" title="About" bezelStyle="shadowlessSquare" image="NSInfo" imagePosition="leading" alignment="center" lineBreakMode="truncatingTail" borderStyle="border" inset="2" id="nQy-nk-Vts">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                         <font key="font" metaFont="system"/>
                                     </buttonCell>
                                 </button>
                                 <customView verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="DZT-CR-EY2">
-                                    <rect key="frame" x="280" y="0.0" width="270" height="38"/>
+                                    <rect key="frame" x="276" y="0.0" width="274" height="38"/>
                                 </customView>
                             </subviews>
                             <constraints>
@@ -93,14 +93,12 @@
                                         <rect key="frame" x="0.0" y="0.0" width="550" height="148"/>
                                         <subviews>
                                             <gridView xPlacement="leading" yPlacement="center" rowAlignment="none" translatesAutoresizingMaskIntoConstraints="NO" id="8wI-wf-FiW">
-                                                <rect key="frame" x="0.0" y="0.0" width="447" height="154"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="447" height="139"/>
                                                 <rows>
                                                     <gridRow id="XZL-na-geY"/>
                                                     <gridRow id="ziJ-5D-O0w"/>
                                                     <gridRow id="Uhr-eN-flM"/>
-                                                    <gridRow id="OgE-Hg-t3U"/>
                                                     <gridRow id="kjr-6r-i1L"/>
-                                                    <gridRow id="v3A-83-Eag"/>
                                                     <gridRow id="e9i-ih-Dy0"/>
                                                 </rows>
                                                 <columns>
@@ -110,7 +108,7 @@
                                                 <gridCells>
                                                     <gridCell row="XZL-na-geY" column="4ur-bR-EOi" id="2Qp-R0-Q2j">
                                                         <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K9K-ak-3e4">
-                                                            <rect key="frame" x="-2" y="135" width="85" height="16"/>
+                                                            <rect key="frame" x="-2" y="121" width="85" height="16"/>
                                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Prompt every" id="pOY-yU-zkx">
                                                                 <font key="font" usesAppearanceFont="YES"/>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -120,10 +118,10 @@
                                                     </gridCell>
                                                     <gridCell row="XZL-na-geY" column="II0-JS-5iC" id="cUr-fb-go0">
                                                         <stackView key="contentView" distribution="fill" orientation="horizontal" alignment="centerY" spacing="3" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5B5-US-fZ7">
-                                                            <rect key="frame" x="150" y="132" width="297" height="22"/>
+                                                            <rect key="frame" x="150" y="118" width="297" height="21"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eP2-Vd-05o">
-                                                                    <rect key="frame" x="0.0" y="1" width="35" height="21"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="35" height="21"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="35" id="hAW-cg-GJz"/>
                                                                     </constraints>
@@ -159,7 +157,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sbj-WK-0IT" userLabel="Randomness">
-                                                                    <rect key="frame" x="194" y="1" width="35" height="21"/>
+                                                                    <rect key="frame" x="194" y="0.0" width="35" height="21"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" id="Q5O-Pl-FQs">
                                                                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="O4S-5f-smy"/>
                                                                         <font key="font" metaFont="system"/>
@@ -219,7 +217,7 @@
                                                     </gridCell>
                                                     <gridCell row="ziJ-5D-O0w" column="4ur-bR-EOi" id="Ejt-6i-Gg7">
                                                         <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bVG-ba-4hY">
-                                                            <rect key="frame" x="-2" y="106" width="82" height="16"/>
+                                                            <rect key="frame" x="-2" y="92" width="82" height="16"/>
                                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Day starts at" id="fqS-Zp-fmP">
                                                                 <font key="font" usesAppearanceFont="YES"/>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -229,10 +227,10 @@
                                                     </gridCell>
                                                     <gridCell row="ziJ-5D-O0w" column="II0-JS-5iC" id="0ZP-7v-mk4">
                                                         <stackView key="contentView" distribution="fill" orientation="horizontal" alignment="centerY" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ID9-jw-Ypn">
-                                                            <rect key="frame" x="150" y="102" width="224" height="24"/>
+                                                            <rect key="frame" x="150" y="88" width="229" height="24"/>
                                                             <subviews>
                                                                 <datePicker verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="GzE-jF-9s2" userLabel="Day Start Time Picker">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="85" height="28"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="84" height="28"/>
                                                                     <datePickerCell key="cell" borderStyle="bezel" alignment="left" drawsBackground="NO" id="zfg-6A-xrN">
                                                                         <font key="font" metaFont="system"/>
                                                                         <date key="date" timeIntervalSinceReferenceDate="-978289200">
@@ -245,7 +243,7 @@
                                                                     <accessibility description="snooze until tomorrow time"/>
                                                                 </datePicker>
                                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="S9T-fo-dJ5">
-                                                                    <rect key="frame" x="84" y="3" width="142" height="18"/>
+                                                                    <rect key="frame" x="83" y="3" width="146" height="18"/>
                                                                     <buttonCell key="cell" type="check" title="including weekends" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Obp-1W-Xkq">
                                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                         <font key="font" metaFont="system"/>
@@ -265,7 +263,7 @@
                                                     </gridCell>
                                                     <gridCell row="Uhr-eN-flM" column="4ur-bR-EOi" id="jBw-tg-I0b">
                                                         <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SWC-aK-o3h">
-                                                            <rect key="frame" x="-2" y="76" width="148" height="16"/>
+                                                            <rect key="frame" x="-2" y="62" width="148" height="16"/>
                                                             <textFieldCell key="cell" lineBreakMode="clipping" title="End-of-day summary at" id="Ml4-ZS-lnl">
                                                                 <font key="font" usesAppearanceFont="YES"/>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -275,7 +273,7 @@
                                                     </gridCell>
                                                     <gridCell row="Uhr-eN-flM" column="II0-JS-5iC" id="lK6-dn-YqO">
                                                         <datePicker key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YY2-et-PfP" userLabel="EOD Time picker">
-                                                            <rect key="frame" x="150" y="72" width="85" height="28"/>
+                                                            <rect key="frame" x="150" y="58" width="84" height="28"/>
                                                             <datePickerCell key="cell" borderStyle="bezel" alignment="left" drawsBackground="NO" datePickerMode="range" id="Ewc-ay-xCD">
                                                                 <font key="font" metaFont="system"/>
                                                                 <date key="date" timeIntervalSinceReferenceDate="-978289200">
@@ -288,15 +286,9 @@
                                                             <accessibility description="daily report time"/>
                                                         </datePicker>
                                                     </gridCell>
-                                                    <gridCell row="OgE-Hg-t3U" column="4ur-bR-EOi" headOfMergedCell="FHv-A2-AyK" id="FHv-A2-AyK">
-                                                        <box key="contentView" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="sDR-rf-PJk">
-                                                            <rect key="frame" x="0.0" y="63" width="100" height="5"/>
-                                                        </box>
-                                                    </gridCell>
-                                                    <gridCell row="OgE-Hg-t3U" column="II0-JS-5iC" headOfMergedCell="FHv-A2-AyK" id="CDO-td-m0n"/>
                                                     <gridCell row="kjr-6r-i1L" column="4ur-bR-EOi" id="kpc-aH-1bp">
                                                         <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8o4-sT-8yL">
-                                                            <rect key="frame" x="-2" y="36" width="98" height="16"/>
+                                                            <rect key="frame" x="-2" y="29" width="98" height="16"/>
                                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Global shortcut" id="aQi-xR-NJg">
                                                                 <font key="font" usesAppearanceFont="YES"/>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -306,18 +298,12 @@
                                                     </gridCell>
                                                     <gridCell row="kjr-6r-i1L" column="II0-JS-5iC" id="Zkr-ES-rDM">
                                                         <customView key="contentView" translatesAutoresizingMaskIntoConstraints="NO" id="cdF-qX-q5Y" userLabel="Global Shortcut Holder">
-                                                            <rect key="frame" x="150" y="29" width="100" height="30"/>
+                                                            <rect key="frame" x="150" y="22" width="100" height="30"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="100" placeholder="YES" id="ceF-V1-7iI"/>
                                                             </constraints>
                                                         </customView>
                                                     </gridCell>
-                                                    <gridCell row="v3A-83-Eag" column="4ur-bR-EOi" headOfMergedCell="koT-UJ-Ba6" id="koT-UJ-Ba6">
-                                                        <box key="contentView" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="TgH-9n-lnF">
-                                                            <rect key="frame" x="0.0" y="20" width="100" height="5"/>
-                                                        </box>
-                                                    </gridCell>
-                                                    <gridCell row="v3A-83-Eag" column="II0-JS-5iC" headOfMergedCell="koT-UJ-Ba6" id="aQJ-0X-8Ex"/>
                                                     <gridCell row="e9i-ih-Dy0" column="4ur-bR-EOi" id="POM-qu-6Kj">
                                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wAx-A8-NQw">
                                                             <rect key="frame" x="-2" y="0.0" width="83" height="16"/>
@@ -330,7 +316,7 @@
                                                     </gridCell>
                                                     <gridCell row="e9i-ih-Dy0" column="II0-JS-5iC" id="DWc-uj-aha">
                                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yBg-YU-u89">
-                                                            <rect key="frame" x="148" y="-1" width="22" height="18"/>
+                                                            <rect key="frame" x="148" y="-1" width="18" height="18"/>
                                                             <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="sZE-63-pJL">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -355,11 +341,11 @@
                                     </userDefinedRuntimeAttributes>
                                 </tabViewItem>
                                 <tabViewItem label="About" identifier="" id="NwU-Zn-0aF">
-                                    <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="rMy-Zr-TwQ">
-                                        <rect key="frame" x="0.0" y="0.0" width="550" height="140"/>
+                                    <view key="view" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rMy-Zr-TwQ">
+                                        <rect key="frame" x="0.0" y="0.0" width="550" height="148"/>
                                         <subviews>
                                             <stackView toolTip="https://github.com/yshavit/whatdid/" distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vRX-G9-MoD" userLabel="About VStack">
-                                                <rect key="frame" x="0.0" y="87" width="186" height="53"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="185" height="53"/>
                                                 <subviews>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WTv-mo-8cX">
                                                         <rect key="frame" x="-2" y="37" width="110" height="16"/>
@@ -370,7 +356,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="baseline" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kmp-b1-hsa" userLabel="GH link">
-                                                        <rect key="frame" x="0.0" y="17" width="186" height="16"/>
+                                                        <rect key="frame" x="0.0" y="17" width="185" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YGr-g1-7m4">
                                                                 <rect key="frame" x="-2" y="0.0" width="54" height="16"/>
@@ -381,7 +367,7 @@
                                                                 </textFieldCell>
                                                             </textField>
                                                             <button toolTip="https://github.com/yshavit/whatdid/" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Qgx-ZJ-RmN">
-                                                                <rect key="frame" x="50" y="0.0" width="100" height="16"/>
+                                                                <rect key="frame" x="50" y="0.0" width="99" height="16"/>
                                                                 <buttonCell key="cell" type="bevel" title="yshavit/whatdid" bezelStyle="rounded" alignment="right" imageScaling="proportionallyDown" inset="2" id="yML-a4-nda">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                     <font key="font" metaFont="system"/>
@@ -392,7 +378,7 @@
                                                                 </connections>
                                                             </button>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="s8a-TO-M4g">
-                                                                <rect key="frame" x="148" y="1" width="13" height="11"/>
+                                                                <rect key="frame" x="147" y="1" width="13" height="11"/>
                                                                 <textFieldCell key="cell" controlSize="mini" lineBreakMode="clipping" title="@" id="1yw-Aj-iAg">
                                                                     <font key="font" metaFont="menu" size="9"/>
                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -400,7 +386,7 @@
                                                                 </textFieldCell>
                                                             </textField>
                                                             <button toolTip="https://github.com/yshavit/whatdid/commit/{sha}" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CCA-RA-eto">
-                                                                <rect key="frame" x="159" y="1" width="27" height="11"/>
+                                                                <rect key="frame" x="158" y="1" width="27" height="11"/>
                                                                 <buttonCell key="cell" type="bevel" title="{sha}" bezelStyle="rounded" alignment="right" controlSize="mini" imageScaling="proportionallyDown" inset="2" id="hMN-3N-viT">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                     <font key="font" metaFont="menu" size="9"/>
@@ -425,7 +411,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3K9-EY-10F">
-                                                        <rect key="frame" x="-2" y="0.0" width="190" height="13"/>
+                                                        <rect key="frame" x="-2" y="0.0" width="189" height="13"/>
                                                         <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="{fullversion}" id="Lir-2N-fjv">
                                                             <font key="font" metaFont="systemUltraLight" size="10"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -577,6 +563,6 @@ Gw
     <resources>
         <image name="NSAdvanced" width="32" height="32"/>
         <image name="NSInfo" width="32" height="32"/>
-        <image name="NSTouchBarComposeTemplate" width="21" height="30"/>
+        <image name="NSTouchBarComposeTemplate" width="17" height="15"/>
     </resources>
 </document>


### PR DESCRIPTION
The merged separators were causing Xcode to crash (versions 12.2 and
11.7). They're not very important, so I'm just removing them for now.