### PR TITLE
sizing fixes for day-end report

### DIFF
--- a/whatdid/controllers/DayEndReportController.swift
+++ b/whatdid/controllers/DayEndReportController.swift
@@ -278,6 +278,7 @@ class DayEndReportController: NSViewController {
         wrapper.wantsLayer = true
         wrapper.layer?.masksToBounds = true
         wrapper.addSubview(details)
+        wrapper.widthAnchor.constraint(equalTo: details.widthAnchor).isActive = true
         let zeroHeight = wrapper.heightAnchor.constraint(equalToConstant: 0)
         let contentHeight = wrapper.heightAnchor.constraint(equalTo: details.heightAnchor)
         

--- a/whatdid/controllers/DayEndReportController.swift
+++ b/whatdid/controllers/DayEndReportController.swift
@@ -17,10 +17,10 @@ class DayEndReportController: NSViewController {
     @IBOutlet weak var goalsSummaryGroup: NSView!
     @IBOutlet weak var goalsSummaryStack: NSStackView!
     @IBOutlet weak var projectsScroll: NSScrollView!
-    @IBOutlet weak var projectsScrollHeight: NSLayoutConstraint!
     @IBOutlet weak var projectsContainer: NSStackView!
     @IBOutlet weak var entryStartDatePicker: NSDatePicker!
-    
+    @IBOutlet weak var shockAbsorber: NSView!
+
     var scheduler: Scheduler = DefaultScheduler.instance
     
     override func awakeFromNib() {
@@ -51,7 +51,6 @@ class DayEndReportController: NSViewController {
         entryStartDatePicker.dateValue = thisMorning(assumingNow: now)
         
         updateEntries()
-        resizeAndLayoutIfNeeded()
     }
     
     override func viewWillAppear() {
@@ -70,8 +69,8 @@ class DayEndReportController: NSViewController {
     }
     
     @IBAction func userChangedEntryStartDate(_ sender: Any) {
-        animate(
-            {
+        AnimationHelper.animate(
+            change: {
                 goalsSummaryStack.subviews.forEach { $0.removeFromSuperview() }
                 projectsContainer.subviews.forEach {$0.removeFromSuperview()}
                 let spinner = NSProgressIndicator()
@@ -81,11 +80,11 @@ class DayEndReportController: NSViewController {
                 spinner.style = .spinning
                 spinner.leadingAnchor.constraint(equalTo: projectsContainer.leadingAnchor).isActive = true
                 spinner.trailingAnchor.constraint(equalTo: projectsContainer.trailingAnchor).isActive = true
+                self.resizeAndLayoutIfNeeded()
             },
-            andThen: {
-                self.animate({ self.updateEntries() })
-            }
-        )
+            onComplete: {
+                AnimationHelper.animate(change: self.updateEntries)
+            })
     }
     
     private func updateGoals(since startTime: Date) {
@@ -130,6 +129,8 @@ class DayEndReportController: NSViewController {
         projects.forEach {project in
             // The vstack group for the whole project
             let projectVStack = NSStackView()
+            projectVStack.wantsLayer = true
+            projectVStack.useAutoLayout()
             projectsContainer.addArrangedSubview(projectVStack)
             projectVStack.spacing = 2
             projectVStack.orientation = .vertical
@@ -145,20 +146,22 @@ class DayEndReportController: NSViewController {
             // Tasks box
             let tasksBox = NSBox()
             tasksBox.useAutoLayout()
-            projectVStack.addArrangedSubview(tasksBox)
             tasksBox.setAccessibilityLabel("Tasks for \"\(project.name)\"")
             tasksBox.title = tasksBox.accessibilityLabel()!
             tasksBox.titlePosition = .noTitle
-            tasksBox.leadingAnchor.constraint(equalTo: projectVStack.leadingAnchor, constant: 3).isActive = true
-            tasksBox.trailingAnchor.constraint(equalTo: projectVStack.trailingAnchor, constant: -3).isActive = true
-            setUpDisclosureExpansion(disclosure: projectHeader.disclosure, details: tasksBox)
-            
             let tasksStack = NSStackView()
+            tasksStack.wantsLayer = true
+            tasksStack.useAutoLayout()
             tasksStack.spacing = 0
             tasksStack.orientation = .vertical
             tasksBox.contentView = tasksStack
+            tasksBox.anchorAllSides(to: tasksStack)
             
-            var previousDetailsBottomAnchor : NSLayoutYAxisAnchor?
+            let taskExpansion = setUpDisclosureExpansion(disclosure: projectHeader.disclosure, add: tasksBox, to: projectVStack)
+            projectVStack.addArrangedSubview(taskExpansion)
+            tasksBox.leadingAnchor.constraint(equalTo: projectVStack.leadingAnchor, constant: 3).isActive = true
+            tasksBox.trailingAnchor.constraint(equalTo: projectVStack.trailingAnchor, constant: -3).isActive = true
+            
             project.forEach {task in
                 let taskHeader = ExpandableProgressBar(
                     addTo: tasksStack,
@@ -168,7 +171,6 @@ class DayEndReportController: NSViewController {
                     outOf: allProjectsTotalTime)
                 taskHeader.progressBar.leadingAnchor.constraint(equalTo: projectHeader.progressBar.leadingAnchor).isActive = true
                 taskHeader.progressBar.trailingAnchor.constraint(equalTo: projectHeader.progressBar.trailingAnchor).isActive = true
-                previousDetailsBottomAnchor?.constraint(equalTo: taskHeader.topView.topAnchor, constant: -5).isActive = true
                 
                 let taskDetailsGrid = NSGridView(views: [])
                 taskDetailsGrid.columnSpacing = 4
@@ -180,26 +182,26 @@ class DayEndReportController: NSViewController {
                 taskDetailsGridBox.title = taskDetailsGridBox.accessibilityLabel()!
                 taskDetailsGridBox.titlePosition = .noTitle
                 taskDetailsGridBox.contentView = taskDetailsGrid
-                tasksStack.addArrangedSubview(taskDetailsGridBox)
                 
-                taskDetailsGridBox.leadingAnchor.constraint(equalTo: taskHeader.progressBar.leadingAnchor).isActive = true
-                taskDetailsGridBox.trailingAnchor.constraint(equalTo: taskHeader.progressBar.trailingAnchor).isActive = true
-                
-                previousDetailsBottomAnchor = taskDetailsGridBox.bottomAnchor
-                setUpDisclosureExpansion(disclosure: taskHeader.disclosure, details: taskDetailsGridBox) {state in
-                    // For some reason, especially long (in terms of vertical space) task notes can break the layout when they're hidden:
-                    // It shows up as a large vertial blank space in other tasks. Zeroing out the contents when hidden seems to fix that.
-                    if state == .off {
+                let taskExpansion = setUpDisclosureExpansion(
+                    disclosure: taskHeader.disclosure,
+                    add: taskDetailsGridBox,
+                    to: tasksStack,
+                    beforeShowing: {
+                        self.details(for: task, to: taskDetailsGrid, relativeTo: todayStart)
+                    },
+                    afterHiding: {
                         while taskDetailsGrid.numberOfRows > 0 {
                             taskDetailsGrid.removeRow(at: 0)
                         }
                         while taskDetailsGrid.numberOfColumns > 0 {
                             taskDetailsGrid.removeColumn(at: 0)
                         }
-                    } else {
-                        self.details(for: task, to: taskDetailsGrid, relativeTo: todayStart)
-                    }
-                }
+                        taskDetailsGrid.subviews.forEach({$0.removeFromSuperview()})
+                    })
+                tasksStack.addArrangedSubview(taskExpansion)
+                taskExpansion.leadingAnchor.constraint(equalTo: taskHeader.progressBar.leadingAnchor).isActive = true
+                taskExpansion.trailingAnchor.constraint(equalTo: taskHeader.progressBar.trailingAnchor).isActive = true
             }
         }
     }
@@ -241,51 +243,95 @@ class DayEndReportController: NSViewController {
             grid.addRow(with: fields)
         }
     }
-    
-    private func animate(_ action: () -> Void, duration: Double = 0.5, andThen: (() -> Void)? = nil) {
-        let originalWindowFrameOpt = self.view.window?.frame
-        let originalViewBounds = self.view.bounds
-        AnimationHelper.animate(
-            duration: duration,
-            change: {
-                action()
-                self.resizeAndLayoutIfNeeded()
-                
-                let newViewBounds = self.view.bounds
-                if let window = self.view.window, let originalWindowFrame = originalWindowFrameOpt {
-                    let deltaWidth = newViewBounds.width - originalViewBounds.width
-                    let deltaHeight = newViewBounds.height - originalViewBounds.height
-                    let newWindowFrame = NSRect(
-                        x: originalWindowFrame.minX,
-                        y: originalWindowFrame.minY - deltaHeight,
-                        width: originalWindowFrame.width + deltaWidth,
-                        height: originalWindowFrame.height + deltaHeight)
-                    window.setFrame(newWindowFrame, display: true)
-                }
-            },
-            onComplete: andThen)
-    }
-    
+
     private func resizeAndLayoutIfNeeded() {
         view.layoutSubtreeIfNeeded()
-        projectsScrollHeight.constant = projectsContainer.fittingSize.height
+        let shockAbsorberHeight = shockAbsorber.frame.height
+        growWindow(byY: -shockAbsorberHeight)
+    }
+    
+    private func growWindow(byY height: CGFloat) {
+        guard let window = view.window else {
+            NSLog("no window")
+            return
+        }
+        let originalViewBounds = window.frame
+        let newFrame = NSRect(
+            x: originalViewBounds.minX,
+            y: originalViewBounds.minY - height,
+            width: originalViewBounds.width,
+            height: originalViewBounds.height + height
+        )
+        window.setFrame(newFrame, display: true)
         view.layoutSubtreeIfNeeded()
     }
     
-    private func setUpDisclosureExpansion(disclosure: ButtonWithClosure, details: NSView, extraAction: ((NSButton.StateValue) -> Void)? = nil) {
-        disclosure.onPress {button in
-            self.animate({
-                details.isHidden = button.state == .off
-                if let requestedAction = extraAction {
-                    requestedAction(button.state)
-                }
-            })
+    private func setUpDisclosureExpansion(
+        disclosure: ButtonWithClosure,
+        add details: NSView,
+        to enclosing: NSView,
+        beforeShowing: @escaping Action = {},
+        afterHiding: @escaping Action = {})
+    -> NSView
+    {
+        let wrapper = NSView()
+        wrapper.wantsLayer = true
+        wrapper.layer?.masksToBounds = true
+        wrapper.addSubview(details)
+        let zeroHeight = wrapper.heightAnchor.constraint(equalToConstant: 0)
+        let contentHeight = wrapper.heightAnchor.constraint(equalTo: details.heightAnchor)
+        
+        func setConstraints(toShow: Bool) {
+            // We don't want to do e.g. `contentHeight.isActive = toShow` because we always want to deactivate
+            // the old constraint before activating the new one. Otherwise they can conflict, which causes one to
+            // get thrown out.
+            if toShow {
+                zeroHeight.isActive = false
+                contentHeight.isActive = true
+            } else {
+                contentHeight.isActive = false
+                zeroHeight.isActive = true
+            }
         }
         
-        details.isHidden = disclosure.state == .off
-        if let requestedAction = extraAction {
-            requestedAction(disclosure.state)
+        if disclosure.state == .on {
+            beforeShowing()
+            setConstraints(toShow: true)
+        } else {
+            afterHiding()
+            setConstraints(toShow: false)
         }
+        
+        disclosure.onPress {button in
+            if button.state == .on {
+                beforeShowing()
+                AnimationHelper.animate(
+                    change: {
+                        setConstraints(toShow: true)
+                        let currentHeight = self.view.frame.height
+                        let maxHeight = self.maxViewHeight.constant
+                        var growBy = details.fittingSize.height
+                        if (growBy + currentHeight) > maxHeight {
+                            growBy = maxHeight - currentHeight
+                        }
+                        self.growWindow(byY: growBy)
+                    },
+                    onComplete: {
+                        AnimationHelper.animate(duration: 0.2, change: self.resizeAndLayoutIfNeeded)
+                    })
+            } else {
+                AnimationHelper.animate(
+                    change: {
+                        setConstraints(toShow: false)
+                        self.growWindow(byY: -details.fittingSize.height)
+                    },
+                    onComplete: {
+                        afterHiding()
+                        AnimationHelper.animate(duration: 0.2, change: self.resizeAndLayoutIfNeeded)
+                    })
+            }
+        }
+        return wrapper
     }
     
     struct ExpandableProgressBar {

--- a/whatdid/controllers/DayEndReportController.swift
+++ b/whatdid/controllers/DayEndReportController.swift
@@ -20,7 +20,6 @@ class DayEndReportController: NSViewController {
     @IBOutlet weak var projectsScrollHeight: NSLayoutConstraint!
     @IBOutlet weak var projectsContainer: NSStackView!
     @IBOutlet weak var entryStartDatePicker: NSDatePicker!
-    @IBOutlet weak var versionLabel: NSTextField!
     
     var scheduler: Scheduler = DefaultScheduler.instance
     
@@ -28,7 +27,6 @@ class DayEndReportController: NSViewController {
         if #available(OSX 10.15.4, *) {
             entryStartDatePicker.presentsCalendarOverlay = true
         }
-        versionLabel.stringValue = Version.pretty
     }
     
     private static func createDisclosure(state: NSButton.StateValue)  -> ButtonWithClosure {

--- a/whatdid/controllers/DayEndReportController.xib
+++ b/whatdid/controllers/DayEndReportController.xib
@@ -16,18 +16,17 @@
                 <outlet property="projectsContainer" destination="UTB-GH-C4K" id="QTl-1c-03i"/>
                 <outlet property="projectsScroll" destination="LDw-zz-ziZ" id="ccf-fo-s0s"/>
                 <outlet property="projectsScrollHeight" destination="o6f-K3-YH7" id="2jK-fl-LC2"/>
-                <outlet property="versionLabel" destination="d5X-74-7gY" id="PM5-Ti-8wa"/>
                 <outlet property="view" destination="Qn8-JX-HeH" id="y6a-6x-Afv"/>
                 <outlet property="widthFitsOnScreen" destination="UB3-c9-V8z" id="Rau-r2-VxM"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qn8-JX-HeH" userLabel="Top">
-            <rect key="frame" x="0.0" y="0.0" width="400" height="97"/>
+        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" misplaced="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qn8-JX-HeH" userLabel="Top">
+            <rect key="frame" x="0.0" y="0.0" width="400" height="92"/>
             <subviews>
                 <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pKe-k9-zAn" userLabel="Header Stack">
-                    <rect key="frame" x="0.0" y="73" width="264" height="24"/>
+                    <rect key="frame" x="0.0" y="50" width="264" height="24"/>
                     <subviews>
                         <textField identifier="header_label" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wxD-Lm-qUL" userLabel="Header">
                             <rect key="frame" x="-2" y="4" width="118" height="16"/>
@@ -68,10 +67,10 @@
                     </customSpacing>
                 </stackView>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="hAT-mx-IFG">
-                    <rect key="frame" x="0.0" y="66" width="400" height="5"/>
+                    <rect key="frame" x="0.0" y="43" width="400" height="5"/>
                 </box>
                 <customView focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="V55-nV-Y5s">
-                    <rect key="frame" x="0.0" y="48" width="400" height="16"/>
+                    <rect key="frame" x="0.0" y="25" width="400" height="16"/>
                     <subviews>
                         <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1RQ-eW-vGH" userLabel="Goals Summary Stack">
                             <rect key="frame" x="0.0" y="0.0" width="400" height="16"/>
@@ -103,10 +102,10 @@
                     </constraints>
                 </customView>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="h3O-9g-faO">
-                    <rect key="frame" x="0.0" y="41" width="400" height="5"/>
+                    <rect key="frame" x="0.0" y="18" width="400" height="5"/>
                 </box>
                 <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LDw-zz-ziZ" userLabel="Projects scroll">
-                    <rect key="frame" x="0.0" y="23" width="400" height="16"/>
+                    <rect key="frame" x="0.0" y="0.0" width="400" height="16"/>
                     <clipView key="contentView" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vpo-4L-DGR" userLabel="Projects clip">
                         <rect key="frame" x="0.0" y="0.0" width="400" height="16"/>
                         <subviews>
@@ -168,21 +167,9 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
-                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="syR-WQ-af6">
-                    <rect key="frame" x="0.0" y="16" width="400" height="5"/>
-                </box>
-                <textField identifier="projects_footer" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="d5X-74-7gY" userLabel="Footer">
-                    <rect key="frame" x="-2" y="0.0" width="402" height="14"/>
-                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="version" id="kVE-kT-ED3" userLabel="Footer cell">
-                        <font key="font" metaFont="menu" size="11"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
             </subviews>
             <constraints>
                 <constraint firstItem="V55-nV-Y5s" firstAttribute="width" secondItem="Qn8-JX-HeH" secondAttribute="width" id="9OU-Hb-fFQ"/>
-                <constraint firstAttribute="trailing" secondItem="d5X-74-7gY" secondAttribute="trailing" constant="2" id="IbK-aX-und"/>
                 <constraint firstItem="h3O-9g-faO" firstAttribute="width" secondItem="Qn8-JX-HeH" secondAttribute="width" id="WB1-I0-7hD"/>
                 <constraint firstItem="hAT-mx-IFG" firstAttribute="width" secondItem="Qn8-JX-HeH" secondAttribute="width" id="nCY-3T-gJp"/>
                 <constraint firstItem="LDw-zz-ziZ" firstAttribute="width" secondItem="Qn8-JX-HeH" secondAttribute="width" id="oDo-5Q-hjJ"/>
@@ -193,12 +180,8 @@
                 <integer value="1000"/>
                 <integer value="1000"/>
                 <integer value="1000"/>
-                <integer value="1000"/>
-                <integer value="1000"/>
             </visibilityPriorities>
             <customSpacing>
-                <real value="3.4028234663852886e+38"/>
-                <real value="3.4028234663852886e+38"/>
                 <real value="3.4028234663852886e+38"/>
                 <real value="3.4028234663852886e+38"/>
                 <real value="3.4028234663852886e+38"/>

--- a/whatdid/controllers/DayEndReportController.xib
+++ b/whatdid/controllers/DayEndReportController.xib
@@ -15,18 +15,18 @@
                 <outlet property="maxViewHeight" destination="1ka-g6-16p" id="IdU-SA-mes"/>
                 <outlet property="projectsContainer" destination="UTB-GH-C4K" id="QTl-1c-03i"/>
                 <outlet property="projectsScroll" destination="LDw-zz-ziZ" id="ccf-fo-s0s"/>
-                <outlet property="projectsScrollHeight" destination="o6f-K3-YH7" id="2jK-fl-LC2"/>
+                <outlet property="shockAbsorber" destination="dFU-a1-6Dj" id="p8U-dT-GvY"/>
                 <outlet property="view" destination="Qn8-JX-HeH" id="y6a-6x-Afv"/>
                 <outlet property="widthFitsOnScreen" destination="UB3-c9-V8z" id="Rau-r2-VxM"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" misplaced="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qn8-JX-HeH" userLabel="Top">
-            <rect key="frame" x="0.0" y="0.0" width="400" height="92"/>
+        <stackView wantsLayer="YES" distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qn8-JX-HeH" userLabel="Top">
+            <rect key="frame" x="0.0" y="0.0" width="400" height="98"/>
             <subviews>
-                <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pKe-k9-zAn" userLabel="Header Stack">
-                    <rect key="frame" x="0.0" y="50" width="264" height="24"/>
+                <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pKe-k9-zAn" userLabel="Header Stack">
+                    <rect key="frame" x="0.0" y="74" width="264" height="24"/>
                     <subviews>
                         <textField identifier="header_label" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wxD-Lm-qUL" userLabel="Header">
                             <rect key="frame" x="-2" y="4" width="118" height="16"/>
@@ -66,13 +66,13 @@
                         <real value="3.4028234663852886e+38"/>
                     </customSpacing>
                 </stackView>
-                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="hAT-mx-IFG">
-                    <rect key="frame" x="0.0" y="43" width="400" height="5"/>
+                <box verticalHuggingPriority="1000" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="hAT-mx-IFG">
+                    <rect key="frame" x="0.0" y="67" width="400" height="5"/>
                 </box>
-                <customView focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="V55-nV-Y5s">
-                    <rect key="frame" x="0.0" y="25" width="400" height="16"/>
+                <customView focusRingType="none" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="V55-nV-Y5s">
+                    <rect key="frame" x="0.0" y="49" width="400" height="16"/>
                     <subviews>
-                        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1RQ-eW-vGH" userLabel="Goals Summary Stack">
+                        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1RQ-eW-vGH" userLabel="Goals Summary Stack">
                             <rect key="frame" x="0.0" y="0.0" width="400" height="16"/>
                             <subviews>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mQu-zC-c2Z" userLabel="Goals summary">
@@ -101,18 +101,18 @@
                         <constraint firstItem="1RQ-eW-vGH" firstAttribute="height" secondItem="V55-nV-Y5s" secondAttribute="height" id="vdW-LG-0TW"/>
                     </constraints>
                 </customView>
-                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="h3O-9g-faO">
-                    <rect key="frame" x="0.0" y="18" width="400" height="5"/>
+                <box verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="h3O-9g-faO">
+                    <rect key="frame" x="0.0" y="42" width="400" height="5"/>
                 </box>
-                <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LDw-zz-ziZ" userLabel="Projects scroll">
-                    <rect key="frame" x="0.0" y="0.0" width="400" height="16"/>
-                    <clipView key="contentView" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vpo-4L-DGR" userLabel="Projects clip">
+                <scrollView wantsLayer="YES" verticalHuggingPriority="999" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LDw-zz-ziZ" userLabel="Projects scroll">
+                    <rect key="frame" x="0.0" y="24" width="400" height="16"/>
+                    <clipView key="contentView" wantsLayer="YES" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vpo-4L-DGR" userLabel="Projects clip">
                         <rect key="frame" x="0.0" y="0.0" width="400" height="16"/>
                         <subviews>
-                            <view translatesAutoresizingMaskIntoConstraints="NO" id="W7j-r2-UD7" userLabel="Projects document" customClass="FlippedView" customModule="whatdid" customModuleProvider="target">
+                            <view wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W7j-r2-UD7" userLabel="Projects document" customClass="FlippedView" customModule="whatdid" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="400" height="16"/>
                                 <subviews>
-                                    <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UTB-GH-C4K" userLabel="Projects vstack">
+                                    <stackView wantsLayer="YES" distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UTB-GH-C4K" userLabel="Projects vstack">
                                         <rect key="frame" x="0.0" y="0.0" width="400" height="16"/>
                                         <subviews>
                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SnG-M9-8Cz">
@@ -155,8 +155,9 @@
                         <constraint firstItem="W7j-r2-UD7" firstAttribute="leading" secondItem="LDw-zz-ziZ" secondAttribute="leading" constant="1" id="aql-aV-OJW"/>
                         <constraint firstAttribute="height" relation="lessThanOrEqual" secondItem="UTB-GH-C4K" secondAttribute="height" id="dDz-hE-Ybj"/>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="800" constant="350" id="gqZ-sZ-vJR"/>
+                        <constraint firstItem="W7j-r2-UD7" firstAttribute="height" secondItem="LDw-zz-ziZ" secondAttribute="height" priority="501" id="h6w-1E-UOk"/>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="450" id="kCo-JN-Qur"/>
-                        <constraint firstAttribute="height" priority="800" constant="37" id="o6f-K3-YH7"/>
+                        <constraint firstAttribute="height" priority="800" constant="37" placeholder="YES" id="o6f-K3-YH7"/>
                     </constraints>
                     <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="mcw-YE-dMv">
                         <rect key="frame" x="-100" y="-100" width="398" height="16"/>
@@ -167,6 +168,12 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
+                <customView verticalHuggingPriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="dFU-a1-6Dj" userLabel="Shock Absorber">
+                    <rect key="frame" x="0.0" y="0.0" width="163" height="20"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="20" placeholder="YES" id="cyu-Qz-RCd"/>
+                    </constraints>
+                </customView>
             </subviews>
             <constraints>
                 <constraint firstItem="V55-nV-Y5s" firstAttribute="width" secondItem="Qn8-JX-HeH" secondAttribute="width" id="9OU-Hb-fFQ"/>
@@ -180,8 +187,10 @@
                 <integer value="1000"/>
                 <integer value="1000"/>
                 <integer value="1000"/>
+                <integer value="1000"/>
             </visibilityPriorities>
             <customSpacing>
+                <real value="3.4028234663852886e+38"/>
                 <real value="3.4028234663852886e+38"/>
                 <real value="3.4028234663852886e+38"/>
                 <real value="3.4028234663852886e+38"/>

--- a/whatdid/main/Base.lproj/MainMenu.xib
+++ b/whatdid/main/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,7 +28,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" utility="YES" fullSizeContentView="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="566" y="354" width="480" height="270"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
             <view key="contentView" id="LZk-f4-v4Y">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>

--- a/whatdid/ui_testhook/WhatdidControlHooks.swift
+++ b/whatdid/ui_testhook/WhatdidControlHooks.swift
@@ -84,12 +84,23 @@ class WhatdidControlHooks: NSObject, NSTextFieldDelegate {
 
         divider()
         adder(hideStatusItem)
-        let useAnimationsButton = ButtonWithClosure(checkboxWithTitle: "Use animations", target: nil, action: nil)
-        useAnimationsButton.state = AnimationHelper.use_animations ? .on : .off
-        useAnimationsButton.onPress {button in
-            AnimationHelper.use_animations = button.state == .on
+        
+        let animationFactorStack = NSStackView(orientation: .horizontal)
+        let animationFactorField = NSTextField(string: AnimationHelper.animation_factor.description)
+        animationFactorField.target = self
+        animationFactorField.action = #selector(self.setAnimationFactor(_:))
+        (animationFactorField.cell as? NSTextFieldCell)?.sendsActionOnEndEditing = true
+        animationFactorStack.addArrangedSubview(NSTextField(labelWithString: "Animation factor"))
+        animationFactorStack.addArrangedSubview(animationFactorField)
+        adder(animationFactorStack)
+    }
+    
+    @objc private func setAnimationFactor(_ field: NSTextField) {
+        if let valueAsDouble = Double(field.stringValue) {
+            AnimationHelper.animation_factor = valueAsDouble
         }
-        adder(useAnimationsButton)
+        // whether the parse worked or not, display the normalized current value
+        field.stringValue = AnimationHelper.animation_factor.description
     }
     
     private func setUpActivator() {

--- a/whatdid/util/AnimationHelper.swift
+++ b/whatdid/util/AnimationHelper.swift
@@ -6,27 +6,20 @@ struct AnimationHelper {
     private init() {}
     
     #if UI_TEST
-    static var use_animations = false
+    static var animation_factor = 0.0
     #endif
     
-    static func animate(duration: TimeInterval, change: Action, onComplete: Action? = nil) {
+    static func animate(duration: TimeInterval = 0.5, change: Action, onComplete: Action? = nil) {
+        let actualDuration: TimeInterval
         #if UI_TEST
-        if use_animations {
-            reallyAnimate(duration: duration, change: change, onComplete: onComplete)
-        } else {
-            change()
-            onComplete?()
-        }
+        actualDuration = duration * animation_factor
         #else
-        reallyAnimate(duration: duration, change: change, onComplete: onComplete)
+        actualDuration = duration
         #endif
-    }
-    
-    private static func reallyAnimate(duration: TimeInterval, change: Action, onComplete: Action? = nil) {
         NSAnimationContext.runAnimationGroup(
             {context in
                 context.allowsImplicitAnimation = true
-                context.duration = duration
+                context.duration = actualDuration
                 change()
             },
             completionHandler: onComplete)

--- a/whatdidUITests/UITestBase.swift
+++ b/whatdidUITests/UITestBase.swift
@@ -7,6 +7,8 @@ class UITestBase: XCTestCase {
     private static var app : XCUIApplication?
     /// A point within the status menu item. Access this via `var statusItemPoint`, which calculates it if needed.
     private static var _statusItemPoint: CGPoint?
+    /// Whether we should restart the app at setup, if it's already running
+    private static var shouldRestartApp = false
     
     var app: XCUIApplication {
         UITestBase.app!
@@ -86,6 +88,14 @@ class UITestBase: XCTestCase {
     
     final override func setUp() {
         continueAfterFailure = false
+        if UITestBase.shouldRestartApp {
+            if let app = UITestBase.app {
+                app.terminate()
+                UITestBase.app = nil
+            }
+            UITestBase.shouldRestartApp = false
+        }
+        
         if UITestBase.app == nil {
             UITestBase.launch(withEnv: startupEnv(suppressTutorial: true))
         }
@@ -107,8 +117,7 @@ class UITestBase: XCTestCase {
         } else {
             log("ERROR: couldn't find app, so won't call uiTearDown!")
         }
-        XCUIApplication().terminate()
-        UITestBase.app = nil
+        UITestBase.shouldRestartApp = true
         let now = Date()
         log("Failed at \(now.utcTimestamp) (\(now.timestamp(at: TimeZone(identifier: "US/Eastern")!)))")
         super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)

--- a/whatdidUITests/app/AppUITestBase.swift
+++ b/whatdidUITests/app/AppUITestBase.swift
@@ -278,38 +278,14 @@ class AppUITestBase: UITestBase {
             return ["headerText": headerLabel, "durationText": durationLabel, "disclosure": disclosure, "indicator": indicatorBar]
         }
         
-        func clickDisclosure(until element: XCUIElement, _ existence: Existence) {
+        func clickDisclosure(until element: XCUIElement, isVisible expectedVisibility: Bool) {
             XCTContext.runActivity(named: "Click \(disclosure.simpleDescription)") {context in
                 context.add(XCTAttachment(screenshot: ancestor.screenshot()))
                 disclosure.click()
-                wait(for: "element to \(existence.asVerb)") {
-                    switch existence {
-                    case .exists:
-                        return element.exists
-                    case .isVisible:
-                        return element.isVisible
-                    case .doesNotExist:
-                        return !element.exists
-                    }
+                wait(for: "element to \(expectedVisibility ? "be visible" : "not be visible")") {
+                    return element.isVisible == expectedVisibility
                 }
                 context.add(XCTAttachment(screenshot: ancestor.screenshot()))
-            }
-        }
-    }
-    
-    enum Existence {
-        case exists
-        case isVisible
-        case doesNotExist
-        
-        var asVerb: String {
-            switch self {
-            case .exists:
-                return "exist"
-            case .isVisible:
-                return "be visible"
-            case .doesNotExist:
-                return "not exist"
             }
         }
     }

--- a/whatdidUITests/app/DailyReportTest.swift
+++ b/whatdidUITests/app/DailyReportTest.swift
@@ -77,8 +77,8 @@ class DailyReportTest: AppUITestBase {
                 }
             }
             group("Check tasks for \"project a\"") {
-                XCTAssertFalse(tasksForA.exists)
-                projectA.clickDisclosure(until: tasksForA, .isVisible)
+                XCTAssertFalse(tasksForA.isVisible)
+                projectA.clickDisclosure(until: tasksForA, isVisible: true)
             }
             for task in ["task 1", "task 2"] {
                 group("Check \(task)'s visibility") {
@@ -98,8 +98,8 @@ class DailyReportTest: AppUITestBase {
                     }
                 }
                 group("Details") {
-                    XCTAssertFalse(task1Details.exists)
-                    task1.clickDisclosure(until: task1Details, .isVisible)
+                    XCTAssertFalse(task1Details.isVisible)
+                    task1.clickDisclosure(until: task1Details, isVisible: true)
                     XCTAssertEqual(
                         [
                             "1:15am - 1:27am (12m):",
@@ -111,10 +111,10 @@ class DailyReportTest: AppUITestBase {
                 }
             }
             group("Task 1 stays expanded if project a folds") {
-                projectA.clickDisclosure(until: task1Details, .doesNotExist)
+                projectA.clickDisclosure(until: task1Details, isVisible: false)
                 log("Sleeping for a bit to let things stabilize")
                 sleep(2) // Clicking too quickly in a row can break this test
-                projectA.clickDisclosure(until: task1Details, .isVisible)
+                projectA.clickDisclosure(until: task1Details, isVisible: true)
             }
         }
     }

--- a/whatdidUITests/app/ScreenshotGenerator.swift
+++ b/whatdidUITests/app/ScreenshotGenerator.swift
@@ -72,11 +72,11 @@ class ScreenshotGenerator: AppUITestBase {
             let testInfraTasks = report.groups["Tasks for \"test infrastructure\""]
             group("expand 'test infrastructure' project") {
                 let testInfraProject = HierarchicalEntryLevel(ancestor: report, scope: "Project", label: "test infrastructure")
-                testInfraProject.clickDisclosure(until: testInfraTasks, .isVisible)
+                testInfraProject.clickDisclosure(until: testInfraTasks, isVisible: true)
             }
             group("expand details for design doc task") {
                 let designDocTask = HierarchicalEntryLevel(ancestor: report, scope: "Task", label: "design doc")
-                designDocTask.clickDisclosure(until: testInfraTasks.groups["Details for design doc"], .isVisible)
+                designDocTask.clickDisclosure(until: testInfraTasks.groups["Details for design doc"], isVisible: true)
             }
             screenshot(named: "daily report", of: report)
         }


### PR DESCRIPTION
This fixes #210, though not in a super great way. I fixed the
"permanent" issues (views growing too large, and then not shrinking
again), but the transitions are pretty iffy. But, I think it's good
enough for 1.0.

Included in this is a refining of the UI hook's animation knob. Rather
than just being a boolean, it's a double now, which is the speed factor
to apply to all animations. Each animation will take `k * d` seconds,
where `d` is its stated duration in the code, and `k` is the factor; so
to effectively disable animations, set `k = 0`.
