### PR TITLE
improved logging

### DIFF
--- a/WhatdidLauncher/AppDelegate.swift
+++ b/WhatdidLauncher/AppDelegate.swift
@@ -1,6 +1,7 @@
 // Taken from https://theswiftdev.com/how-to-launch-a-macos-app-at-login/
 
 import Cocoa
+import os
 
 extension Notification.Name {
     static let killLauncher = Notification.Name("killLauncher")
@@ -22,10 +23,10 @@ extension AppDelegate: NSApplicationDelegate {
         let isRunning = !runningApps.filter { $0.bundleIdentifier == mainAppIdentifier }.isEmpty
 
         if isRunning {
-            NSLog("whatdid launcher: whatdid is already running")
+            os_log(.info, "whatdid launcher: whatdid is already running")
             self.terminate()
         } else {
-            NSLog("whatdid launcher: will try to launch whatdid")
+            os_log(.info, "whatdid launcher: will try to launch whatdid")
             DistributedNotificationCenter.default().addObserver(self, selector: #selector(self.terminate), name: .killLauncher, object: mainAppIdentifier)
 
             let path = Bundle.main.bundlePath as NSString
@@ -37,13 +38,13 @@ extension AppDelegate: NSApplicationDelegate {
             components.append("whatdid") //main app name
 
             let newPath = NSString.path(withComponents: components)
-            NSLog("whatdid launcher about to launch: \(newPath)")
+            os_log(.info, "whatdid launcher about to launch: %@", newPath)
 
             NSWorkspace.shared.launchApplication(newPath)
         }
     }
     
     func applicationWillTerminate(_ notification: Notification) {
-        NSLog("whatdid launcher is exiting")
+        os_log(.info, "whatdid launcher is exiting")
     }
 }

--- a/whatdid.xcodeproj/project.pbxproj
+++ b/whatdid.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		7EA6E22824BD6C5F004B9297 /* PtnViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7EA6E22724BD6C5F004B9297 /* PtnViewController.xib */; };
 		7EAB5ECD24DA366600E18097 /* TimeUtilTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAB5ECC24DA366600E18097 /* TimeUtilTest.swift */; };
 		7EAD2A4B2626CBB100153A47 /* ScrollBarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAD2A4A2626CBB100153A47 /* ScrollBarHelper.swift */; };
+		7EAD2A6726291D1800153A47 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAD2A6626291D1800153A47 /* Logger.swift */; };
+		7EAD2A6D2629271800153A47 /* OSLogType+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAD2A6C2629271800153A47 /* OSLogType+Helpers.swift */; };
 		7EB57AA825187549009E85F5 /* NSApperance+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB57AA725187548009E85F5 /* NSApperance+Helpers.swift */; };
 		7EB7495B251699FD001C7DBC /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 7EB7495A251699FD001C7DBC /* KeyboardShortcuts */; };
 		7EB7495D25169A44001C7DBC /* GlobalShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB7495C25169A44001C7DBC /* GlobalShortcut.swift */; };
@@ -204,6 +206,8 @@
 		7EA6E22724BD6C5F004B9297 /* PtnViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PtnViewController.xib; sourceTree = "<group>"; };
 		7EAB5ECC24DA366600E18097 /* TimeUtilTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimeUtilTest.swift; path = whatdidTests/scheduling/TimeUtilTest.swift; sourceTree = SOURCE_ROOT; };
 		7EAD2A4A2626CBB100153A47 /* ScrollBarHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollBarHelper.swift; sourceTree = "<group>"; };
+		7EAD2A6626291D1800153A47 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		7EAD2A6C2629271800153A47 /* OSLogType+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OSLogType+Helpers.swift"; sourceTree = "<group>"; };
 		7EB57AA725187548009E85F5 /* NSApperance+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSApperance+Helpers.swift"; sourceTree = "<group>"; };
 		7EB7495C25169A44001C7DBC /* GlobalShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalShortcut.swift; sourceTree = "<group>"; };
 		7EB7495E2516F9C7001C7DBC /* Prefs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Prefs.swift; sourceTree = "<group>"; };
@@ -448,6 +452,7 @@
 			children = (
 				7E88CC8D261EB5A900968F64 /* AnimationHelper.swift */,
 				7E30B46024C38D91003F3679 /* Atomic.swift */,
+				7EAD2A6626291D1800153A47 /* Logger.swift */,
 				7EB7495E2516F9C7001C7DBC /* Prefs.swift */,
 				7EAD2A4A2626CBB100153A47 /* ScrollBarHelper.swift */,
 				7EE0E73F24E4DF4A002D03F8 /* SubsequenceMatcher.swift */,
@@ -547,6 +552,7 @@
 				7E5EFA262619B14A00E7834D /* NSTextField+Helpers.swift */,
 				7EE0E74924EA22E7002D03F8 /* NSView+Helpers.swift */,
 				7EF884102610139B00170330 /* NSViewController+Helper.swift */,
+				7EAD2A6C2629271800153A47 /* OSLogType+Helpers.swift */,
 				7EE0E74724EA1ECD002D03F8 /* String+Helpers.swift */,
 				7E51DA08250BF5C60088864F /* TimeZone+Helpers.swift */,
 			);
@@ -847,7 +853,9 @@
 				7E9C5EBE260C09AA00D839C4 /* Goal+CoreDataProperties.swift in Sources */,
 				7E37A29124BFFFCB005BA1DF /* Project+CoreDataProperties.swift in Sources */,
 				7EF857A124E2420C00867832 /* Scheduler.swift in Sources */,
+				7EAD2A6D2629271800153A47 /* OSLogType+Helpers.swift in Sources */,
 				7EF58F8C2580F180002F9604 /* TutorialViewController.swift in Sources */,
+				7EAD2A6726291D1800153A47 /* Logger.swift in Sources */,
 				7EF884172610151A00170330 /* TypeAliases.swift in Sources */,
 				7E37A29024BFFFCB005BA1DF /* Project+CoreDataClass.swift in Sources */,
 				7E5EFA272619B14A00E7834D /* NSTextField+Helpers.swift in Sources */,

--- a/whatdid/controllers/DayEndReportController.swift
+++ b/whatdid/controllers/DayEndReportController.swift
@@ -44,7 +44,7 @@ class DayEndReportController: NSViewController {
         // Set the window's max height, using the golden ratio.
         if let screenHeight = view.window?.screen?.frame.height {
             maxViewHeight.constant = screenHeight * 0.61802903
-            NSLog("set max height to %.1f (screen height is %.1f)", maxViewHeight.constant, screenHeight)
+            wdlog(.debug, "set max height to %.1f (screen height is %.1f)", maxViewHeight.constant, screenHeight)
         }
         // Set up the date picker
         let now = scheduler.now
@@ -136,7 +136,7 @@ class DayEndReportController: NSViewController {
     
     private func updateEntries() {
         let since = entryStartDatePicker.dateValue
-        NSLog("Updating entries since %@", since as NSDate)
+        wdlog(.debug, "Updating entries since %@", since as NSDate)
         updateGoals(since: since)
         projectsContainer.subviews.forEach {$0.removeFromSuperview()}
         
@@ -269,7 +269,7 @@ class DayEndReportController: NSViewController {
     
     private func growWindow(byY height: CGFloat) {
         guard let window = view.window else {
-            NSLog("no window")
+            wdlog(.warn, "Asked to grow window, but there is no window")
             return
         }
         let originalViewBounds = window.frame

--- a/whatdid/controllers/DayStartController.swift
+++ b/whatdid/controllers/DayStartController.swift
@@ -48,7 +48,7 @@ class DayStartController: NSViewController, NSTextFieldDelegate, CloseConfirmer 
                 goalTexts.forEach { let _ = model.createNewGoal(goal: $0) }
             }
         } else if !goalTexts.isEmpty {
-            NSLog("saveGoalsOnExit was nil, but there were goal texts; not saving goals. This is unexpected.")
+            wdlog(.warn, "saveGoalsOnExit was nil, but there were goal texts; not saving goals. This is unexpected.")
         }
         // We have to clear the entries before closing, or else the "save goals?" alert will show
         self.goalEntries.forEach({$0.removeGoal()})

--- a/whatdid/controllers/PrefsViewController.swift
+++ b/whatdid/controllers/PrefsViewController.swift
@@ -173,11 +173,11 @@ class PrefsViewController: NSViewController {
             }
             dateComponents.calendar = calendarForDateTimePickers
             dateComponents.timeZone = calendarForDateTimePickers.timeZone
-            NSLog("Converting DateComponents to Date: \(dateComponents)")
+            wdlog(.debug, "Converting DateComponents to Date: %@", dateComponents.description)
             if let date = dateComponents.date {
                 picker.dateValue = date
             } else {
-                NSLog("Couldn't convert DateComponents to Date: \(dateComponents)")
+                wdlog(.warn, "Couldn't convert DateComponents to Date: %@", dateComponents.description)
             }
         }
         setTimePicker(dailyReportTime, to: Prefs.dailyReportTime)
@@ -253,7 +253,7 @@ class PrefsViewController: NSViewController {
         if let location = sender.toolTip, let url = URL(string: location) {
             NSWorkspace.shared.open(url)
         } else {
-            NSLog("invalid href: \(sender.toolTip ?? "<nil>")")
+            wdlog(.warn, "invalid href: %@", sender.toolTip ?? "<nil>")
         }
     }
     

--- a/whatdid/controllers/PtnViewController.swift
+++ b/whatdid/controllers/PtnViewController.swift
@@ -234,7 +234,7 @@ class PtnViewController: NSViewController {
         if let date = until as? Date {
             hooks?.snooze(until: date)
         } else {
-            NSLog("error: date not set up (was \(until ?? "nil"))")
+            wdlog(.error, "date not set up (was %@)", until.debugDescription)
         }
     }
     

--- a/whatdid/extensions/NSButton+Helpers.swift
+++ b/whatdid/extensions/NSButton+Helpers.swift
@@ -25,7 +25,7 @@ extension NSButton {
         func cycleOnce() {
             let style = allStyles[i]
             i = (i + 1) % allStyles.count
-            NSLog("styling as: \(style.0)")
+            wdlog(.info, "styling as: %@", style.0)
             bezelStyle = style.1
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .milliseconds(1000), execute: cycleOnce)
         }

--- a/whatdid/extensions/NSViewController+Helper.swift
+++ b/whatdid/extensions/NSViewController+Helper.swift
@@ -61,16 +61,16 @@ extension NSViewController {
                 let startNewSession: Bool
                 switch(response) {
                 case .OK:
-                    NSLog("Starting new session")
+                    wdlog(.debug, "Starting new session")
                     startNewSession = true
                 case .continue:
-                    NSLog("Continuing with existing session")
+                    wdlog(.debug, "Continuing with existing session")
                     startNewSession = false
                 case .abort:
-                    NSLog("Aborting window (probably because user closed it via status menu item)")
+                    wdlog(.debug, "Aborting window (probably because user closed it via status menu item)")
                     startNewSession = false
                 default:
-                    NSLog("Unexpected response: \(response.rawValue). Will start new session session.")
+                    wdlog(.warn, "Unexpected response: %@. Will start new session session.", response.rawValue)
                     startNewSession = false
                 }
                 if startNewSession {

--- a/whatdid/extensions/OSLogType+Helpers.swift
+++ b/whatdid/extensions/OSLogType+Helpers.swift
@@ -1,0 +1,24 @@
+// whatdid?
+
+import os
+
+extension OSLogType {
+    /// Equivalent to `.default`.
+    ///
+    /// This is a clearer label for that `.default`'s description:
+    /// "Use this level to capture information about things that might result in a failure."
+    static let warn = OSLogType.default
+    
+    var asString: String {
+        get {
+            switch self {
+            case .debug:   return "DEBUG"
+            case .default: return "WARN "
+            case .error:   return "ERROR"
+            case .fault:   return "FAULT"
+            case .info:    return "INFO "
+            default:       return "(log@\(rawValue))"
+            }
+        }
+    }
+}

--- a/whatdid/main/AppDelegate.swift
+++ b/whatdid/main/AppDelegate.swift
@@ -37,6 +37,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         resetModel()
         kickOffInitialSchedules()
         resetAllPrefs()
+        globalLogHook.reset()
     }
     #endif
     
@@ -47,16 +48,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func applicationDidFinishLaunching(_: Notification) {
-        NSLog("Starting whatdid with build %@", Version.pretty)
+        wdlog(.info, "Starting whatdid with build %@", Version.pretty)
         #if UI_TEST
         NSApp.setActivationPolicy(.regular) // so that the windows show up normally
-        NSLog("initializing UI test hooks")
+        wdlog(.info, "initializing UI test hooks")
         uiTestWindow = UiTestWindow()
         uiTestWindow.show()
         NSApp.setActivationPolicy(.regular) // UI tests can time out on launch() without this
         if let bundleId = Bundle.main.bundleIdentifier {
             oldPrefs = UserDefaults.standard.persistentDomain(forName: bundleId)
-            NSLog("Removing old preferences because this is a UI test. Saved \(oldPrefs?.count ?? 0) to restore later.")
+            wdlog(.info, "Removing old preferences because this is a UI test. Saved %d to restore later.", oldPrefs?.count ?? 0)
             UserDefaults.standard.setPersistentDomain([String: Any](), forName: bundleId)
         }
         #endif
@@ -100,10 +101,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         #if UI_TEST
         if let bundleId = Bundle.main.bundleIdentifier {
             if let toRestore = oldPrefs {
-                NSLog("Restoring old preferences")
+                wdlog(.info, "Restoring old preferences")
                 UserDefaults.standard.setPersistentDomain(toRestore, forName: bundleId)
             } else {
-                NSLog("No previous preferences to restore")
+                wdlog(.info, "No previous preferences to restore")
             }
         }
         #endif
@@ -124,7 +125,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         Prefs.$launchAtLogin.addListener {enabled in
             let success = SMLoginItemSetEnabled(launcherAppId as CFString, enabled)
-            NSLog("SMLoginItemSetEnabled -> \(enabled) \(success ? "successfully set" : "NOT set")")
+            wdlog(success ? .info : .warn, "SMLoginItemSetEnabled -> %d %@", enabled, success ? "successfully set" : "NOT set")
         }
 
         if isRunning {

--- a/whatdid/main/AutoCompletingField.swift
+++ b/whatdid/main/AutoCompletingField.swift
@@ -104,7 +104,7 @@ fileprivate class AutoCompletingFieldView: WhatdidTextField, NSTextViewDelegate,
             parent.nextKeyView
         }
         set(value) {
-            NSLog("Unexpected mutation of AutoCompletingFieldView.nextKeyView")
+            wdlog(.warn, "Unexpected mutation of AutoCompletingFieldView.nextKeyView")
         }
     }
     
@@ -113,7 +113,7 @@ fileprivate class AutoCompletingFieldView: WhatdidTextField, NSTextViewDelegate,
         if parent.popupManager.windowIsVisible, let window = window {
             let popup = parent.popupManager.window
             guard window.screen == popup.screen else {
-                NSLog("window screen and autocomplete popup screen were different")
+                wdlog(.warn, "window screen and autocomplete popup screen were different")
                 return
             }
             let myBoundsWithinWindow = convert(bounds, to: nil)
@@ -283,11 +283,11 @@ fileprivate class AutoCompletingFieldView: WhatdidTextField, NSTextViewDelegate,
         if popupManager.windowIsVisible {
             // Note: we shouldn't ever actually get here, but I'm putting it just in case.
             // If the popup is open, any click outside of it (including to this button) will close it.
-            NSLog("Unexpectedly saw button press while options popup was open on \(idForLogging)")
+            wdlog(.warn, "Unexpectedly saw button press while options popup was open on %@", idForLogging)
             popupManager.close()
         } else {
             if !(window?.makeFirstResponder(self) ?? false) {
-                NSLog("Couldn't make first responder: \(idForLogging)")
+                wdlog(.error, "Couldn't make first responder: %@", idForLogging)
             }
             showOptions()
         }
@@ -650,7 +650,7 @@ fileprivate class PopupManager: NSObject, NSWindowDelegate {
                         if let editor = parent.textField.currentEditor() {
                             editor.insertNewline(nil) // send the action
                         } else {
-                            NSLog("Couldn't find editor")
+                            wdlog(.error, "Couldn't find editor in AutoCompletingField")
                         }
                         break
                     }

--- a/whatdid/model/FlatEntry+Serde.swift
+++ b/whatdid/model/FlatEntry+Serde.swift
@@ -1,6 +1,11 @@
 // whatdid?
 #if UI_TEST
 import Cocoa
+import os
+
+// NOTE: This file gets compiled both in main whatdid and whatdidUITests.
+// The latter doesn't have access to `wdlog`, so we can't use that here.
+
 extension FlatEntry {
     
     static func deserialize(from json: String) -> [FlatEntry] {
@@ -13,11 +18,11 @@ extension FlatEntry {
             do {
                 return try decoder.decode([FlatEntry].self, from: jsonData)
             } catch {
-                NSLog("Error deserializing \(json): \(error)")
+                os_log(.error, "Error deserializing %@: %@", json, error as NSError)
                 return []
             }
         } else {
-            NSLog("Couldn't get UTF-8 data from string: \(json)")
+            os_log(.error, "Couldn't get UTF-8 data from string: %@", json)
             return []
         }
     }
@@ -36,7 +41,7 @@ extension FlatEntry {
             let jsonData = try encoder.encode(entries)
             return String(data: jsonData, encoding: .utf8)!
         } catch {
-            NSLog("failed to encode \(self): \(error)")
+            os_log(.error, "failed to encode entries: %@", String(describing: entries), error as NSError)
             return ""
         }
     }

--- a/whatdid/scheduling/DelegatingScheduler.swift
+++ b/whatdid/scheduling/DelegatingScheduler.swift
@@ -26,7 +26,7 @@ class DelegatingScheduler: Scheduler {
     
     @discardableResult func schedule(_ description: String, at: Date, _ block: @escaping () -> Void) -> ScheduledTask {
         guard isOpen else {
-            NSLog("Ignoring task because DelegatingScheduler has been closed")
+            wdlog(.debug, "Ignoring task because DelegatingScheduler has been closed")
             return NoopTask()
         }
         let work = createTrackingBlock(block)

--- a/whatdid/scheduling/ManualTickScheduler.swift
+++ b/whatdid/scheduling/ManualTickScheduler.swift
@@ -14,7 +14,7 @@ class ManualTickScheduler: Scheduler {
     }
     
     @discardableResult func schedule(_ description: String, at date: Date, _ block: @escaping () -> Void) -> ScheduledTask {
-        NSLog("Scheduling \(description) at \(date) (t+\(date.timeIntervalSinceWhatdidNow))")
+        wdlog(.debug, "Scheduling %@ at %@ (t+%.0f)", description, date as NSDate, date.timeIntervalSinceWhatdidNow)
         if date == _now {
             enqueueAction(block)
             return NoopScheduledItem()
@@ -23,7 +23,7 @@ class ManualTickScheduler: Scheduler {
             events.append(WorkItem(id: uuid, fireAt: date, block: block))
             return ManualScheduledItem(parent: self, id: uuid)
         } else {
-            NSLog("ignoring event because it's in the past (\(date))")
+            wdlog(.warn, "ignoring event because it's in the past (%@)", date as NSDate)
             return NoopScheduledItem()
         }
     }

--- a/whatdid/scheduling/OpenReason.swift
+++ b/whatdid/scheduling/OpenReason.swift
@@ -3,4 +3,8 @@
 enum OpenReason {
     case manual
     case scheduled
+    
+    var description: String {
+        return String(describing: self)
+    }
 }

--- a/whatdid/scheduling/SystemClockScheduler.swift
+++ b/whatdid/scheduling/SystemClockScheduler.swift
@@ -27,7 +27,7 @@ class SystemClockScheduler: Scheduler {
     }
     
     @objc private func handleWakeup(_ notification: Notification) {
-        NSLog("Rescheduling \(pendingTasks.count) task(s)")
+        wdlog(.debug, "Rescheduling %d task(s)", pendingTasks.count)
         pendingTasks.values.forEach {$0.reschedule()}
     }
     
@@ -68,10 +68,10 @@ class SystemClockScheduler: Scheduler {
             cancelWorkItem()
             let timeLeft = deadline.timeIntervalSinceWhatdidNow
             if timeLeft <= 0 {
-                NSLog("Running \(description) immediately")
+                wdlog(.debug, "Running %@ immediately", description)
                 DispatchQueue.main.async(execute: runBlock)
             } else {
-                NSLog("Scheduling \(description) at \(deadline)")
+                wdlog(.debug, "Scheduling %@ at %@", description, deadline as NSDate)
                 workItem = DispatchWorkItem(qos: .utility, block: runBlock)
                 DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + timeLeft, execute: workItem!)
             }

--- a/whatdid/scheduling/TimeUtil.swift
+++ b/whatdid/scheduling/TimeUtil.swift
@@ -48,7 +48,6 @@ class TimeUtil {
         var cal = Calendar.current
         cal.timeZone = tz ?? DefaultScheduler.instance.timeZone
         var result = cal.date(bySettingHour: hh, minute: mm, second: 00, of: now)
-        NSLog("Finding %@ time at %02d:%02d. Now=%@, initial result = %@", direction.rawValue, hh, mm, now.debugDescription, result.debugDescription)
         switch direction {
         case .previous:
             // We want a result < now, so if result > now, decrement it by a day

--- a/whatdid/ui_testhook/PasteboardView.swift
+++ b/whatdid/ui_testhook/PasteboardView.swift
@@ -53,20 +53,20 @@ class PasteboardView: NSView {
             if let data = pasteboard.string(forType: .string) {
                 action?(data)
             } else {
-                NSLog("no string for pasteboard \(pasteboard.name.rawValue)")
+                wdlog(.warn, "no string for pasteboard %@", pasteboard.name.rawValue)
             }
             setUp(pasteboard: nil)
         } else {
             let new = NSPasteboard.withUniqueName()
             new.declareTypes([.string], owner: nil)
-            NSLog("created pasteboard: \(new.name.rawValue)")
+            wdlog(.debug, "created pasteboard: %@", new.name.rawValue)
             setUp(pasteboard: new)
         }
     }
 
     private func setUp(pasteboard: NSPasteboard?) {
         if let old = self.pasteboard {
-            NSLog("released pasteboard: \(old.name.rawValue)")
+            wdlog(.debug, "released pasteboard: %@", old.name.rawValue)
             old.releaseGlobally()
         }
         self.pasteboard = pasteboard

--- a/whatdid/ui_testhook/WhatdidControlHooks.swift
+++ b/whatdid/ui_testhook/WhatdidControlHooks.swift
@@ -118,7 +118,7 @@ class WhatdidControlHooks: NSObject, NSTextFieldDelegate {
         ]
         let timeFormatter = DateFormatter()
         timeFormatter.locale = Locale(identifier: "en_US_POSIX")
-        timeFormatter.dateFormat = "HH:mm"
+        timeFormatter.dateFormat = "HH:mm:ss"
         globalLogHook =
             LogHook(
                 add: {level, message in

--- a/whatdid/util/Logger.swift
+++ b/whatdid/util/Logger.swift
@@ -1,0 +1,58 @@
+// whatdid?
+
+import Cocoa
+import os
+
+#if UI_TEST
+var globalLogHook = LogHook(add: {_, _ in}, reset: {})
+
+private func logToHook(_ type: OSLogType, _ message: String) {
+    if Thread.current.isMainThread {
+        globalLogHook.add(type, message)
+    } else {
+        DispatchQueue.main.async {
+            globalLogHook.add(type, message)
+        }
+    }
+}
+
+struct LogHook {
+    let add: (OSLogType, String) -> ()
+    let reset: Action
+}
+#endif
+
+// Note: we need all these dumb overloads because you can't pass an array into a vararg in Swift.
+// (or rather you can, but it comes through as a single element in the vararg).
+
+func wdlog(_ type: OSLogType, _ message: StaticString) {
+    os_log(type, message)
+    #if UI_TEST
+    logToHook(type, s(message))
+    #endif
+}
+
+func wdlog(_ type: OSLogType, _ message: StaticString, _ arg0: CVarArg) {
+    os_log(type, message, arg0)
+    #if UI_TEST
+    logToHook(type, String(format: s(message), arg0))
+    #endif
+}
+
+func wdlog(_ type: OSLogType, _ message: StaticString, _ arg0: CVarArg, _ arg1: CVarArg) {
+    os_log(type, message, arg0, arg1)
+    #if UI_TEST
+    logToHook(type, String(format: s(message), arg0, arg1))
+    #endif
+}
+
+func wdlog(_ type: OSLogType, _ message: StaticString, _ arg0: CVarArg, _ arg1: CVarArg, _ arg2: CVarArg) {
+    os_log(type, message, arg0, arg1, arg2)
+    #if UI_TEST
+    logToHook(type, String(format: s(message), arg0, arg1, arg2))
+    #endif
+}
+
+private func s(_ source: StaticString) -> String {
+    return source.withUTF8Buffer { String(decoding: $0, as: UTF8.self) }
+}

--- a/whatdid/util/Prefs.swift
+++ b/whatdid/util/Prefs.swift
@@ -126,7 +126,7 @@ struct HoursAndMinutes: PrefType {
     init(hours: Int, minutes: Int) {
         self.hours = hours
         if minutes < 0 || minutes > 59 {
-            NSLog("Invalid minutes for HoursAndMinutes: \(hours):\(minutes). Assuming minutes=00")
+            wdlog(.error, "Invalid minutes for HoursAndMinutes: %d:%d. Assuming minutes=00", hours, minutes)
             self.minutes = 0
         } else {
             self.minutes = minutes

--- a/whatdid/util/ScrollBarHelper.swift
+++ b/whatdid/util/ScrollBarHelper.swift
@@ -37,7 +37,7 @@ class ScrollBarHelper {
         case .overlay:
             scrollShows = false
         @unknown default:
-            NSLog("uknown value for NSScroller.preferredScrollerStyle: \(currentStyle.rawValue)")
+            wdlog(.warn, "uknown value for NSScroller.preferredScrollerStyle: %d", currentStyle.rawValue)
             scrollShows = true
         }
         handler(scrollShows && !scroller.isHidden)

--- a/whatdid/util/SubsequenceMatcher.swift
+++ b/whatdid/util/SubsequenceMatcher.swift
@@ -34,7 +34,7 @@ class SubsequenceMatcher {
             } else {
                 for range in matchedRanges {
                     if (range.location < 0) || (range.location + range.length > string.count) {
-                        NSLog("bad range: \(range) in \(string)")
+                        wdlog(.error, "bad range: %@ in %@", range.description, string)
                         return nil
                     }
                 }

--- a/whatdidUITests/app/AppUITestBase.swift
+++ b/whatdidUITests/app/AppUITestBase.swift
@@ -62,6 +62,12 @@ class AppUITestBase: UITestBase {
     }
     
     override func uiTearDown() {
+        activate()
+        let logs = app.windows["UI Test Window"].textViews["uitestlogstream"].stringValue
+        let attachment = XCTAttachment(string: logs)
+        attachment.name = "logs for \(self.description)"
+        add(attachment)
+        
         clearPasteboardIfNeeded()
     }
     

--- a/whatdidUITests/app/ScreenshotGenerator.swift
+++ b/whatdidUITests/app/ScreenshotGenerator.swift
@@ -117,7 +117,7 @@ class ScreenshotGenerator: AppUITestBase {
         screenshot.image.draw(at: .zero, from: sourceFrame, operation: .copy, fraction: 1.0)
         cropped.unlockFocus()
         
-        NSLog("taking screenshot")
+        log("taking screenshot")
         let attachment = XCTAttachment(image: cropped)
         attachment.lifetime = .keepAlways
         attachment.name = name.replacingOccurrences(of: " ", with: "-")


### PR DESCRIPTION
This is to help understand our flakey tests (#209). With this change, we
log more correctly (using `os_log` instead of `NSLog`, the latter of
which is actually meant just for warnings), but also fork those log
messages over to the app control window in UI tests. This lets us copy
them and add them as an attachment, which should make it easier to debug
failures.