### PR TITLE
session management

### DIFF
--- a/whatdid.xcodeproj/project.pbxproj
+++ b/whatdid.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		7E7C384E24DF33A000CFF3E7 /* FlatEntry+Serde.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C384D24DF33A000CFF3E7 /* FlatEntry+Serde.swift */; };
 		7E7C384F24DF33A000CFF3E7 /* FlatEntry+Serde.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C384D24DF33A000CFF3E7 /* FlatEntry+Serde.swift */; };
 		7E7C385224DF36D000CFF3E7 /* FlatEntry+SerdeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C385124DF36D000CFF3E7 /* FlatEntry+SerdeTest.swift */; };
+		7E7D006D262BFC08002D4CB5 /* ConfirmViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7D006B262BFC08002D4CB5 /* ConfirmViewController.swift */; };
+		7E7D006E262BFC08002D4CB5 /* ConfirmViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7E7D006C262BFC08002D4CB5 /* ConfirmViewController.xib */; };
 		7E88CC8E261EB5A900968F64 /* AnimationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E88CC8D261EB5A900968F64 /* AnimationHelper.swift */; };
 		7E88F5AA2529AB46002B2F2E /* Int+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E88F5A92529AB46002B2F2E /* Int+Helpers.swift */; };
 		7E8C04DE23714F0700A0C3A6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8C04DD23714F0700A0C3A6 /* AppDelegate.swift */; };
@@ -181,6 +183,8 @@
 		7E7C384A24DF2E5E00CFF3E7 /* FlatEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlatEntry.swift; sourceTree = "<group>"; };
 		7E7C384D24DF33A000CFF3E7 /* FlatEntry+Serde.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FlatEntry+Serde.swift"; sourceTree = "<group>"; };
 		7E7C385124DF36D000CFF3E7 /* FlatEntry+SerdeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FlatEntry+SerdeTest.swift"; sourceTree = "<group>"; };
+		7E7D006B262BFC08002D4CB5 /* ConfirmViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmViewController.swift; sourceTree = "<group>"; };
+		7E7D006C262BFC08002D4CB5 /* ConfirmViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ConfirmViewController.xib; sourceTree = "<group>"; };
 		7E88CC8D261EB5A900968F64 /* AnimationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationHelper.swift; sourceTree = "<group>"; };
 		7E88F5A92529AB46002B2F2E /* Int+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Helpers.swift"; sourceTree = "<group>"; };
 		7E8C04DA23714F0700A0C3A6 /* whatdid.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = whatdid.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -501,6 +505,8 @@
 			isa = PBXGroup;
 			children = (
 				7E1EE6612612EEF1003314EE /* CloseConfirmer.swift */,
+				7E7D006B262BFC08002D4CB5 /* ConfirmViewController.swift */,
+				7E7D006C262BFC08002D4CB5 /* ConfirmViewController.xib */,
 				7E07C3B624D121770007FD23 /* DayEndReportController.swift */,
 				7E07C3B724D121770007FD23 /* DayEndReportController.xib */,
 				7EF883FA260D7DD400170330 /* DayStartController.swift */,
@@ -759,6 +765,7 @@
 				7EA6E22624BD61FD004B9297 /* MainMenu.xib in Resources */,
 				7E970D6924DA84AF00F634AB /* UiTestWindow.xib in Resources */,
 				7EF883FD260D7DD400170330 /* DayStartController.xib in Resources */,
+				7E7D006E262BFC08002D4CB5 /* ConfirmViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -867,6 +874,7 @@
 				7EE0E74024E4DF4A002D03F8 /* SubsequenceMatcher.swift in Sources */,
 				7E970D6B24DA850D00F634AB /* UiTestWindow.swift in Sources */,
 				7E6C98D22503EF4900A712EB /* DelegatingScheduler.swift in Sources */,
+				7E7D006D262BFC08002D4CB5 /* ConfirmViewController.swift in Sources */,
 				7EB57AA825187549009E85F5 /* NSApperance+Helpers.swift in Sources */,
 				7E1EE6622612EEF1003314EE /* CloseConfirmer.swift in Sources */,
 				7EDA369524D6A95B00F5E368 /* TimeUtil.swift in Sources */,

--- a/whatdid/controllers/ConfirmViewController.swift
+++ b/whatdid/controllers/ConfirmViewController.swift
@@ -75,6 +75,7 @@ class ConfirmViewController: NSViewController {
         let confirmWindow = NSWindow(contentRect: window.frame, styleMask: [.titled], backing: .buffered, defer: true)
         confirmWindow.backgroundColor = NSColor.windowBackgroundColor
         confirmWindow.contentViewController = self
+        confirmWindow.initialFirstResponder = cancelButton
         widthConstraint.constant = window.frame.width
         minHeightConstraint.constant = window.frame.height
         return {

--- a/whatdid/controllers/ConfirmViewController.swift
+++ b/whatdid/controllers/ConfirmViewController.swift
@@ -1,0 +1,86 @@
+// whatdid?
+
+import Cocoa
+
+class ConfirmViewController: NSViewController {
+    @IBOutlet weak private var headerField: NSTextField!
+    @IBOutlet weak private var detailsField: NSTextField!
+    @IBOutlet weak private var minHeightConstraint: NSLayoutConstraint!
+    @IBOutlet weak private var widthConstraint: NSLayoutConstraint!
+    @IBOutlet weak private var proceedButton: NSButton!
+    @IBOutlet weak private var cancelButton: NSButton!
+    
+    var onProceed = {}
+    
+    var header: String {
+        get {
+            headerField.stringValue
+        }
+        set (value) {
+            headerField.stringValue = value
+        }
+    }
+    
+    var detail: String {
+        get {
+            detailsField.stringValue
+        }
+        set (value) {
+            detailsField.stringValue = value
+        }
+    }
+    
+    var proceedButtonText: String {
+        get {
+            proceedButton.title
+        }
+        set (value) {
+            proceedButton.title = value
+        }
+    }
+    
+    var cancelButtonText: String {
+        get {
+            cancelButton.title
+        }
+        set (value) {
+            cancelButton.title = value
+        }
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    @objc private func handleButton(_ button: NSButton) {
+        wdlog(.debug, "handling button: %@", button.title)
+    }
+
+    @IBAction func handleProceed(_ sender: Any) {
+        onProceed()
+        endParentSheet(with: .OK)
+    }
+    
+    @IBAction func handleCancel(_ sender: Any) {
+        endParentSheet(with: .cancel)
+    }
+    
+    private func endParentSheet(with response: NSApplication.ModalResponse) {
+        if let myWindow = view.window, let mySheetParent = myWindow.sheetParent {
+            mySheetParent.endSheet(myWindow, returnCode: response)
+        }
+    }
+    
+    func prepareToAttach(to window: NSWindow) -> Action {
+        let confirmWindow = NSWindow(contentRect: window.frame, styleMask: [.titled], backing: .buffered, defer: true)
+        confirmWindow.backgroundColor = NSColor.windowBackgroundColor
+        confirmWindow.contentViewController = self
+        widthConstraint.constant = window.frame.width
+        minHeightConstraint.constant = window.frame.height
+        return {
+            window.beginSheet(confirmWindow)
+            confirmWindow.makeKeyAndOrderFront(self)
+        }
+    }
+    
+}

--- a/whatdid/controllers/ConfirmViewController.xib
+++ b/whatdid/controllers/ConfirmViewController.xib
@@ -22,7 +22,7 @@
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cGX-M3-Ieh">
                     <rect key="frame" x="8" y="71" width="317" height="16"/>
-                    <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" title="Confirmation" id="ge8-mQ-8rZ">
+                    <textFieldCell key="cell" lineBreakMode="clipping" allowsUndo="NO" title="Confirmation" id="ge8-mQ-8rZ">
                         <font key="font" textStyle="headline" name=".SFNS-Bold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -30,7 +30,7 @@
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="xEc-Zk-K0c">
                     <rect key="frame" x="8" y="47" width="317" height="16"/>
-                    <textFieldCell key="cell" refusesFirstResponder="YES" allowsUndo="NO" title="Are you sure you want to do this?" id="ISj-Qk-xnR">
+                    <textFieldCell key="cell" allowsUndo="NO" title="Are you sure you want to do this?" id="ISj-Qk-xnR">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -50,17 +50,18 @@
                         </customView>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gYA-0o-MPz">
                             <rect key="frame" x="238" y="-7" width="56" height="32"/>
-                            <buttonCell key="cell" type="push" title="Yes" bezelStyle="rounded" alignment="center" refusesFirstResponder="YES" borderStyle="border" inset="2" id="onb-PM-MOA">
+                            <buttonCell key="cell" type="push" title="Yes" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="onb-PM-MOA">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
                             </buttonCell>
                             <connections>
                                 <action selector="handleProceed:" target="-2" id="3PL-mS-Fjc"/>
+                                <outlet property="nextKeyView" destination="fFA-jn-okU" id="w5x-8e-fnL"/>
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fFA-jn-okU">
                             <rect key="frame" x="288" y="-7" width="52" height="32"/>
-                            <buttonCell key="cell" type="push" title="No" bezelStyle="rounded" alignment="center" refusesFirstResponder="YES" borderStyle="border" inset="2" id="v1v-EP-RzV">
+                            <buttonCell key="cell" type="push" title="No" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="v1v-EP-RzV">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
                                 <string key="keyEquivalent" base64-UTF8="YES">
@@ -69,6 +70,7 @@ Gw
                             </buttonCell>
                             <connections>
                                 <action selector="handleCancel:" target="-2" id="TP7-al-Z4F"/>
+                                <outlet property="nextKeyView" destination="gYA-0o-MPz" id="n4m-Pc-mCW"/>
                             </connections>
                         </button>
                     </subviews>

--- a/whatdid/controllers/ConfirmViewController.xib
+++ b/whatdid/controllers/ConfirmViewController.xib
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="ConfirmViewController" customModule="whatdid" customModuleProvider="target">
+            <connections>
+                <outlet property="cancelButton" destination="fFA-jn-okU" id="7A5-1S-nGH"/>
+                <outlet property="detailsField" destination="xEc-Zk-K0c" id="eZG-Vo-TKt"/>
+                <outlet property="headerField" destination="cGX-M3-Ieh" id="cyi-Ry-9pc"/>
+                <outlet property="minHeightConstraint" destination="bCA-hJ-K7Y" id="bwK-yd-WuD"/>
+                <outlet property="proceedButton" destination="gYA-0o-MPz" id="F0k-jP-VTa"/>
+                <outlet property="view" destination="6vA-c9-69k" id="a0A-v2-ygZ"/>
+                <outlet property="widthConstraint" destination="3G6-9I-UpE" id="L1L-T4-AHk"/>
+            </connections>
+        </customObject>
+        <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="500" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6vA-c9-69k" userLabel="Top Stack">
+            <rect key="frame" x="0.0" y="0.0" width="333" height="91"/>
+            <subviews>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cGX-M3-Ieh">
+                    <rect key="frame" x="8" y="71" width="317" height="16"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" title="Confirmation" id="ge8-mQ-8rZ">
+                        <font key="font" textStyle="headline" name=".SFNS-Bold"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="xEc-Zk-K0c">
+                    <rect key="frame" x="8" y="47" width="317" height="16"/>
+                    <textFieldCell key="cell" refusesFirstResponder="YES" allowsUndo="NO" title="Are you sure you want to do this?" id="ISj-Qk-xnR">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Yxl-Bm-6Wu">
+                    <rect key="frame" x="10" y="36" width="323" height="5"/>
+                </box>
+                <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vGf-s4-XLm" userLabel="Buttons Stack">
+                    <rect key="frame" x="0.0" y="10" width="333" height="20"/>
+                    <subviews>
+                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="9wu-WI-FcK">
+                            <rect key="frame" x="0.0" y="15" width="237" height="5"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="5" id="xyr-wg-hGJ"/>
+                            </constraints>
+                        </customView>
+                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gYA-0o-MPz">
+                            <rect key="frame" x="238" y="-7" width="56" height="32"/>
+                            <buttonCell key="cell" type="push" title="Yes" bezelStyle="rounded" alignment="center" refusesFirstResponder="YES" borderStyle="border" inset="2" id="onb-PM-MOA">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="handleProceed:" target="-2" id="3PL-mS-Fjc"/>
+                            </connections>
+                        </button>
+                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fFA-jn-okU">
+                            <rect key="frame" x="288" y="-7" width="52" height="32"/>
+                            <buttonCell key="cell" type="push" title="No" bezelStyle="rounded" alignment="center" refusesFirstResponder="YES" borderStyle="border" inset="2" id="v1v-EP-RzV">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="system"/>
+                                <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                            </buttonCell>
+                            <connections>
+                                <action selector="handleCancel:" target="-2" id="TP7-al-Z4F"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <visibilityPriorities>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                    </visibilityPriorities>
+                    <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                    </customSpacing>
+                </stackView>
+            </subviews>
+            <edgeInsets key="edgeInsets" left="10" right="10" top="4" bottom="10"/>
+            <constraints>
+                <constraint firstAttribute="width" constant="333" id="3G6-9I-UpE"/>
+                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="80" id="bCA-hJ-K7Y"/>
+                <constraint firstItem="vGf-s4-XLm" firstAttribute="trailing" secondItem="Yxl-Bm-6Wu" secondAttribute="trailing" id="vFj-IR-cZJ"/>
+            </constraints>
+            <visibilityPriorities>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+                <integer value="1000"/>
+            </visibilityPriorities>
+            <customSpacing>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+                <real value="3.4028234663852886e+38"/>
+            </customSpacing>
+            <point key="canvasLocation" x="37.5" y="92"/>
+        </stackView>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+    </objects>
+</document>

--- a/whatdid/controllers/PtnViewController.swift
+++ b/whatdid/controllers/PtnViewController.swift
@@ -138,24 +138,26 @@ class PtnViewController: NSViewController {
             self.snoozeUntil = Date(timeIntervalSince1970: defaultSnoozeDate.timeIntervalSince1970)
             let refreshOptionsAt = defaultSnoozeDate.addingTimeInterval(-300)
             snoozeExtraOptions.isEnabled = true
-            for menuItem in snoozeExtraOptions.itemArray.filter({$0.title.starts(with: "+")}) {
-                if let plusMinutes = Int(menuItem.title) {
+            for menuItem in snoozeExtraOptions.itemArray {
+                let plusMinutes = menuItem.tag
+                if plusMinutes > 0 {
                     let optionSnoozeDate = defaultSnoozeDate.addingTimeInterval(TimeInterval(plusMinutes) * 60.0)
                     menuItem.title = TimeUtil.formatSuccinctly(date: optionSnoozeDate)
                     menuItem.representedObject = optionSnoozeDate
                 }
             }
+            
             let nextSessionHhMm = untilTomorrowSettings?.hhMm ?? Prefs.dayStartTime
             let nextSessionWeekends = untilTomorrowSettings?.includeWeekends ?? Prefs.daysIncludeWeekends
-            
-            let latestDate = snoozeExtraOptions.itemArray.compactMap({$0.representedObject as? Date}).last ?? defaultSnoozeDate
-            
+            let latestDate = snoozeExtraOptions.itemArray
+                .filter({$0.tag > 0})
+                .compactMap({$0.representedObject as? Date})
+                .last
+                ?? defaultSnoozeDate
             let nextSessionDate = nextSessionHhMm.map {hh, mm in
                 TimeUtil.dateForTime(.next, hh: hh, mm: mm, excludeWeekends: !nextSessionWeekends, assumingNow: latestDate)}
-            if let nextSessionItem = snoozeExtraOptions.lastItem {
-                nextSessionItem.title = TimeUtil.formatSuccinctly(date: nextSessionDate)
-                nextSessionItem.representedObject = nextSessionDate
-            }
+            snoozeUntilTomorrow.title = TimeUtil.formatSuccinctly(date: nextSessionDate)
+            snoozeUntilTomorrow.representedObject = nextSessionDate
             
             scheduler.schedule("Snooze options refresh", at: refreshOptionsAt, updateSnoozeButton)
         }

--- a/whatdid/controllers/PtnViewController.swift
+++ b/whatdid/controllers/PtnViewController.swift
@@ -235,6 +235,37 @@ class PtnViewController: NSViewController {
         }
     }
     
+    @IBAction func handleSkipSessionButton(_ sender: Any) {
+        if let window = view.window {
+            let confirm = ConfirmViewController()
+            let showConfirmation = confirm.prepareToAttach(to: window)
+            let duration = TimeUtil.daysHoursMinutes(
+                for: scheduler.timeInterval(since: AppDelegate.instance.model.lastEntryDate))
+            confirm.header = "Skip this session?"
+            confirm.detail = """
+            If you skip this session, the last \(duration) will not be recorded.
+
+            You cannot undo this action.
+
+            If you took a break, consider recording it as such. For example:
+            break / social media / looking at friends' pictures
+            """
+            confirm.proceedButtonText = "Skip session"
+            confirm.cancelButtonText = "Don't skip"
+            confirm.onProceed = skipSession
+            showConfirmation()
+        } else {
+            wdlog(.warn, "can't find window to post confirmation alert in skipSession. Will proceed with skipping session.")
+            skipSession()
+        }
+    }
+    
+    private func skipSession() {
+        AppDelegate.instance.model.setLastEntryDateToNow()
+        self.closeWindowAsync()
+    }
+    
+    
     @IBAction func preferenceButtonPressed(_ sender: NSButton) {
         if let viewWindow = view.window {
             let prefsWindow = NSWindow(contentRect: viewWindow.frame, styleMask: [.titled], backing: .buffered, defer: true)

--- a/whatdid/controllers/PtnViewController.swift
+++ b/whatdid/controllers/PtnViewController.swift
@@ -8,19 +8,20 @@ class PtnViewController: NSViewController {
     public static let CURRENT_TUTORIAL_VERSION = 0
 
     @IBOutlet var topStack: NSStackView!
-    
     @IBOutlet var headerText: NSTextField!
     
     @IBOutlet weak var prefsButton: NSButton!
     @IBOutlet weak var projectField: AutoCompletingField!
     @IBOutlet weak var taskField: AutoCompletingField!
     @IBOutlet weak var noteField: NSTextField!
+    
     @IBOutlet var goals: GoalsView!
     
     @IBOutlet weak var snoozeButton: NSButton!
     private var snoozeUntil : Date?
     @IBOutlet weak var snoozeExtraOptions: NSPopUpButton!
     private var snoozeOptionsUpdateSpinner: NSProgressIndicator?
+    @IBOutlet weak var snoozeUntilTomorrow: NSMenuItem!
     
     private var optionIsPressed = false
     
@@ -128,33 +129,27 @@ class PtnViewController: NSViewController {
             snoozeExtraOptions.isEnabled = false
             scheduler.schedule("Snooze options refresh", at: alreadySnoozedUntil, updateSnoozeButton)
         } else {
-            // Set up the snooze button. We'll have 4 options at half-hour increments, starting 10 minutes from now.
+            // Set up the snooze button to be now + 10 minutes, rounded up to the
+            // closest half-hour.
             // The 10 minutes is so that if it's currently 2:29:59, you won't be annoyed with a "snooze until 2:30" button.
-            let bufferMinutes = 10
-            let snoozeIntervalMinutes = 30.0
-            
-            let now = scheduler.now
-            var snoozeUntil = now.addingTimeInterval(TimeInterval(bufferMinutes * 60))
-            // Round it up (always up) to the nearest half-hour
-            let incrementInterval = Double(snoozeIntervalMinutes * 60.0)
-            snoozeUntil = Date(timeIntervalSince1970: (snoozeUntil.timeIntervalSince1970 / incrementInterval).rounded(.up) * incrementInterval)
+            let defaultSnoozeDate = TimeUtil.roundUp(scheduler.now, bufferedByMinute: 10, toClosestMinute: 30)
 
-            snoozeButton.title = "Snooze until \(TimeUtil.formatSuccinctly(date: snoozeUntil))   " // extra space for the pulldown option
-            self.snoozeUntil = Date(timeIntervalSince1970: snoozeUntil.timeIntervalSince1970)
-            let refreshOptionsAt = snoozeUntil.addingTimeInterval(-300)
-            var latestDate = snoozeUntil
+            snoozeButton.title = "Snooze until \(TimeUtil.formatSuccinctly(date: defaultSnoozeDate))   " // extra space for the pulldown option
+            self.snoozeUntil = Date(timeIntervalSince1970: defaultSnoozeDate.timeIntervalSince1970)
+            let refreshOptionsAt = defaultSnoozeDate.addingTimeInterval(-300)
             snoozeExtraOptions.isEnabled = true
-            for menuItem in snoozeExtraOptions.itemArray[1...] {
-                if menuItem.isSeparatorItem {
-                    break
+            for menuItem in snoozeExtraOptions.itemArray.filter({$0.title.starts(with: "+")}) {
+                if let plusMinutes = Int(menuItem.title) {
+                    let optionSnoozeDate = defaultSnoozeDate.addingTimeInterval(TimeInterval(plusMinutes) * 60.0)
+                    menuItem.title = TimeUtil.formatSuccinctly(date: optionSnoozeDate)
+                    menuItem.representedObject = optionSnoozeDate
                 }
-                snoozeUntil.addTimeInterval(incrementInterval)
-                menuItem.title = TimeUtil.formatSuccinctly(date: snoozeUntil)
-                latestDate = Date(timeIntervalSince1970: snoozeUntil.timeIntervalSince1970)
-                menuItem.representedObject = latestDate
             }
             let nextSessionHhMm = untilTomorrowSettings?.hhMm ?? Prefs.dayStartTime
             let nextSessionWeekends = untilTomorrowSettings?.includeWeekends ?? Prefs.daysIncludeWeekends
+            
+            let latestDate = snoozeExtraOptions.itemArray.compactMap({$0.representedObject as? Date}).last ?? defaultSnoozeDate
+            
             let nextSessionDate = nextSessionHhMm.map {hh, mm in
                 TimeUtil.dateForTime(.next, hh: hh, mm: mm, excludeWeekends: !nextSessionWeekends, assumingNow: latestDate)}
             if let nextSessionItem = snoozeExtraOptions.lastItem {

--- a/whatdid/controllers/PtnViewController.xib
+++ b/whatdid/controllers/PtnViewController.xib
@@ -67,9 +67,9 @@
                                         <menu key="menu" id="e29-UZ-3Z2">
                                             <items>
                                                 <menuItem state="on" hidden="YES" id="ntA-xD-jFV" userLabel="snooze"/>
-                                                <menuItem title="+30" id="Dfs-KT-zJY" userLabel="+30"/>
-                                                <menuItem title="+60" id="S09-6Y-I7d" userLabel="I"/>
-                                                <menuItem title="+90" id="BbM-Gt-GCN" userLabel="+1h30"/>
+                                                <menuItem title="tag:+30m" tag="30" id="Dfs-KT-zJY" userLabel="+30m"/>
+                                                <menuItem title="tag:+1h" tag="60" id="S09-6Y-I7d" userLabel="+1h"/>
+                                                <menuItem title="tag:+1h30m" tag="90" id="BbM-Gt-GCN" userLabel="+1h30m"/>
                                                 <menuItem isSeparatorItem="YES" id="Fju-ZH-G90"/>
                                                 <menuItem title="until tomorrow" id="qvY-Zm-z6P">
                                                     <modifierMask key="keyEquivalentModifierMask"/>

--- a/whatdid/controllers/PtnViewController.xib
+++ b/whatdid/controllers/PtnViewController.xib
@@ -15,6 +15,7 @@
                 <outlet property="projectField" destination="4Lo-U3-YED" id="7SV-al-VYn"/>
                 <outlet property="snoozeButton" destination="yjZ-yA-5CH" id="kMR-QE-XYq"/>
                 <outlet property="snoozeExtraOptions" destination="2d3-tf-ady" id="sU1-Fq-fTJ"/>
+                <outlet property="snoozeUntilTomorrow" destination="qvY-Zm-z6P" id="q3v-bx-6bh"/>
                 <outlet property="taskField" destination="sxc-2C-mp9" id="Pro-Vo-fL6"/>
                 <outlet property="topStack" destination="HWg-YQ-y10" id="uHE-m7-vJd"/>
                 <outlet property="view" destination="HWg-YQ-y10" id="KfA-3s-tIh"/>
@@ -28,7 +29,7 @@
                     <rect key="frame" x="334" y="153" width="534" height="28"/>
                     <subviews>
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="v8p-Bz-hcj" userLabel="Header text">
-                            <rect key="frame" x="-2" y="0.0" width="326" height="28"/>
+                            <rect key="frame" x="-2" y="0.0" width="376" height="28"/>
                             <textFieldCell key="cell" title="What have you been working on for the last {DURATION} (since {TIME})?" id="MHs-V5-IyC">
                                 <font key="font" metaFont="label" size="11"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -37,7 +38,7 @@
                             <accessibility identifier="durationheader"/>
                         </textField>
                         <customView verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="maZ-n4-VKP" userLabel="Spacer">
-                            <rect key="frame" x="328" y="4" width="50" height="24"/>
+                            <rect key="frame" x="378" y="4" width="0.0" height="24"/>
                         </customView>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="HC6-YQ-v0e" userLabel="Snooze buttonopts">
                             <rect key="frame" x="384" y="14" width="130" height="14"/>
@@ -67,8 +68,8 @@
                                             <items>
                                                 <menuItem state="on" hidden="YES" id="ntA-xD-jFV" userLabel="snooze"/>
                                                 <menuItem title="+30" id="Dfs-KT-zJY" userLabel="+30"/>
-                                                <menuItem title="+1h" id="S09-6Y-I7d" userLabel="+1h"/>
-                                                <menuItem title="+1h30" id="BbM-Gt-GCN" userLabel="+1h30"/>
+                                                <menuItem title="+60" id="S09-6Y-I7d" userLabel="I"/>
+                                                <menuItem title="+90" id="BbM-Gt-GCN" userLabel="+1h30"/>
                                                 <menuItem isSeparatorItem="YES" id="Fju-ZH-G90"/>
                                                 <menuItem title="until tomorrow" id="qvY-Zm-z6P">
                                                     <modifierMask key="keyEquivalentModifierMask"/>

--- a/whatdid/controllers/PtnViewController.xib
+++ b/whatdid/controllers/PtnViewController.xib
@@ -74,6 +74,13 @@
                                                 <menuItem title="until tomorrow" id="qvY-Zm-z6P">
                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                 </menuItem>
+                                                <menuItem isSeparatorItem="YES" id="llj-na-JYd"/>
+                                                <menuItem title="Skip this session" id="rJf-mO-GWd">
+                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                    <connections>
+                                                        <action selector="handleSkipSessionButton:" target="-2" id="5PZ-ZC-krg"/>
+                                                    </connections>
+                                                </menuItem>
                                             </items>
                                         </menu>
                                     </popUpButtonCell>

--- a/whatdid/extensions/NSViewController+Helper.swift
+++ b/whatdid/extensions/NSViewController+Helper.swift
@@ -80,7 +80,7 @@ extension NSViewController {
                     wdlog(.debug, "Aborting window (probably because user closed it via status menu item)")
                     startNewSession = false
                 default:
-                    wdlog(.warn, "Unexpected response: %@. Will start new session session.", response.rawValue)
+                    wdlog(.warn, "Unexpected response: %d. Will start new session session.", response.rawValue)
                     startNewSession = false
                 }
                 if startNewSession {

--- a/whatdid/extensions/NSViewController+Helper.swift
+++ b/whatdid/extensions/NSViewController+Helper.swift
@@ -51,17 +51,16 @@ extension NSViewController {
             optionsStack.orientation = .horizontal
             optionsStack.widthAnchor.constraint(equalTo: mainStack.widthAnchor).isActive = true
             
-            let newSession = ButtonWithClosure(label: "Start new session") {_ in
+            let newSessionButton = ButtonWithClosure(label: "Start new session") {_ in
                 window.endSheet(sheet, returnCode: .OK)
             }
-            optionsStack.addView(newSession, in: .center)
+            optionsStack.addView(newSessionButton, in: .center)
             
-            let continueSession = ButtonWithClosure(label: "Continue with current session") {_ in
+            let continueSessionButton = ButtonWithClosure(label: "Continue with current session") {_ in
                 window.endSheet(sheet, returnCode: .continue)
             }
-            optionsStack.addView(continueSession, in: .center)
+            optionsStack.addView(continueSessionButton, in: .center)
             controller.flasher = {
-                // TODO change this to flash the buttons
                 wdlog(.debug, "refusing to close while long-session prompt is open")
             }
             

--- a/whatdid/main/MainMenu.swift
+++ b/whatdid/main/MainMenu.swift
@@ -87,10 +87,16 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate, PtnViewDel
     }
     
     func windowShouldClose(_ sender: NSWindow) -> Bool {
-        if let closeConfirmer = contentViewController as? CloseConfirmer,
-           !closeConfirmer.requestClose(on: sender)
-        {
-            return false
+        if let window = window {
+            // Get all of the sheets (in top-to-bottom order), and then the current window.
+            // That means that whatever the user sees has first crack at refusing the close.
+            let allWindows = window.sheets + [window]
+            let allCloseConfirmers = allWindows.compactMap({$0.contentViewController as? CloseConfirmer})
+            for closeConfirmer in allCloseConfirmers {
+                if !closeConfirmer.requestClose(on: sender) {
+                    return false
+                }
+            }
         }
         cancelClose = false
         opener.didClose()

--- a/whatdid/main/MainMenu.swift
+++ b/whatdid/main/MainMenu.swift
@@ -21,6 +21,9 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate, PtnViewDel
         // in the opener logic.
         unSnooze()
         if let window = window {
+            for sheet in window.sheets {
+                window.endSheet(sheet)
+            }
             for _ in WindowContents.allCases {
                 _ = windowShouldClose(window)
             }

--- a/whatdid/main/MainMenu.swift
+++ b/whatdid/main/MainMenu.swift
@@ -22,7 +22,7 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate, PtnViewDel
         unSnooze()
         if let window = window {
             for sheet in window.sheets {
-                window.endSheet(sheet)
+                window.endSheet(sheet, returnCode: .cancel)
             }
             for _ in WindowContents.allCases {
                 _ = windowShouldClose(window)

--- a/whatdid/model/Model.swift
+++ b/whatdid/model/Model.swift
@@ -88,6 +88,7 @@ class Model {
     }()
     
     func setLastEntryDateToNow() {
+        wdlog(.info, "Skipping session")
         _lastEntryDate = DefaultScheduler.instance.now
     }
     

--- a/whatdid/scheduling/SystemClockScheduler.swift
+++ b/whatdid/scheduling/SystemClockScheduler.swift
@@ -66,7 +66,7 @@ class SystemClockScheduler: Scheduler {
         
         func reschedule() {
             cancelWorkItem()
-            let timeLeft = deadline.timeIntervalSinceWhatdidNow
+            let timeLeft = deadline.timeIntervalSinceNow
             if timeLeft <= 0 {
                 wdlog(.debug, "Running %@ immediately", description)
                 DispatchQueue.main.async(execute: runBlock)

--- a/whatdid/scheduling/TimeUtil.swift
+++ b/whatdid/scheduling/TimeUtil.swift
@@ -117,6 +117,14 @@ class TimeUtil {
         return calendar.dateComponents([.day], from: nowStart, to: thenStart).day ?? 0
     }
     
+    static func roundUp(_ date: Date, bufferedByMinute buffer: Int, toClosestMinute intervalMinutes: Int) -> Date {
+        let intervalSeconds = TimeInterval(intervalMinutes * 60)
+        let secondsSinceEpoch = date.timeIntervalSince1970 + TimeInterval(buffer * 60)
+        let intervalsSinceEpoch = secondsSinceEpoch / intervalSeconds
+        let intervalsRoundedUp = intervalsSinceEpoch.rounded(.up)
+        return Date(timeIntervalSince1970: intervalsRoundedUp * intervalSeconds)
+    }
+    
     enum TimeDirection : String {
         case previous
         case next

--- a/whatdid/ui_testhook/WhatdidControlHooks.swift
+++ b/whatdid/ui_testhook/WhatdidControlHooks.swift
@@ -90,6 +90,7 @@ class WhatdidControlHooks: NSObject, NSTextFieldDelegate {
         animationFactorField.target = self
         animationFactorField.action = #selector(self.setAnimationFactor(_:))
         (animationFactorField.cell as? NSTextFieldCell)?.sendsActionOnEndEditing = true
+        animationFactorField.setAccessibilityLabel("uitestanimationfactor")
         animationFactorStack.addArrangedSubview(NSTextField(labelWithString: "Animation factor"))
         animationFactorStack.addArrangedSubview(animationFactorField)
         adder(animationFactorStack)

--- a/whatdidUITests/app/LongSessionPromptTest.swift
+++ b/whatdidUITests/app/LongSessionPromptTest.swift
@@ -60,9 +60,9 @@ class LongSessionPromptTest: AppUITestBase {
         checkSessionReset(
             onPrompt: {
                 clickStatusMenu()
-                waitForTransition(of: .ptn, toIsVisible: false)
-                clickStatusMenu()
-                waitForTransition(of: .ptn, toIsVisible: true)
+                sleepMillis(1000) // give the PTN time to go away, if it was going to (it shouldn't)
+                XCTAssertEqual(.ptn, openWindowType)
+                handleLongSessionPrompt(on: .ptn, .continueWithCurrentSession)
             },
             expectDateFrom: date(h: 0, m: 00),
             to: date(h: 6, m: 00))

--- a/whatdidUITests/app/LongSessionPromptTest.swift
+++ b/whatdidUITests/app/LongSessionPromptTest.swift
@@ -59,10 +59,14 @@ class LongSessionPromptTest: AppUITestBase {
     func testDismissingWindowRetainsQuestion() {
         checkSessionReset(
             onPrompt: {
-                clickStatusMenu()
-                sleepMillis(1000) // give the PTN time to go away, if it was going to (it shouldn't)
-                XCTAssertEqual(.ptn, openWindowType)
-                handleLongSessionPrompt(on: .ptn, .continueWithCurrentSession)
+                group("try to dismiss via click") {
+                    clickStatusMenu()
+                    sleepMillis(1000) // give the PTN time to go away, if it was going to (it shouldn't)
+                    XCTAssertEqual(.ptn, openWindowType)
+                }
+                group("dismiss prompt") {
+                    handleLongSessionPrompt(on: .ptn, .continueWithCurrentSession)
+                }
             },
             expectDateFrom: date(h: 0, m: 00),
             to: date(h: 6, m: 00))

--- a/whatdidUITests/app/LongSessionPromptTest.swift
+++ b/whatdidUITests/app/LongSessionPromptTest.swift
@@ -55,7 +55,6 @@ class LongSessionPromptTest: AppUITestBase {
             to: date(h: 6, m: 00))
     }
     
-    /// see: [issue #201](https://github.com/yshavit/whatdid/issues/201)
     func testDismissingWindowRetainsQuestion() {
         checkSessionReset(
             onPrompt: {

--- a/whatdidUITests/app/PrefsUITest.swift
+++ b/whatdidUITests/app/PrefsUITest.swift
@@ -31,7 +31,7 @@ class PrefsUITest: AppUITestBase {
                     waitForTransition(of: .ptn, toIsVisible: true)
                 }
                 group("Open preferences back up") {
-                    prefsButton.click()
+                    prefsButton.click(using: .frame())
                     XCTAssertTrue(prefsSheet.isVisible)
                 }
             }

--- a/whatdidUITests/app/PrefsUITest.swift
+++ b/whatdidUITests/app/PrefsUITest.swift
@@ -73,7 +73,9 @@ class PrefsUITest: AppUITestBase {
                         clickStatusMenu() // open ptn
                         snoozeOpts.click()
                         let snoozeOptionLabels = snoozeOptions.allElementsBoundByIndex.map { $0.title }
-                        XCTAssertEqual(["7:00 pm", "7:30 pm", "8:00 pm", "", "Monday at 9:00 am"], snoozeOptionLabels)
+                        XCTAssertEqual(
+                            ["7:00 pm", "7:30 pm", "8:00 pm", "", "Monday at 9:00 am", "", "Skip this session"],
+                            snoozeOptionLabels)
                         prefsButton.click() // once to dismiss the snooze options popup
                         sleepMillis(500)
                         prefsButton.click() // and then to actually click the prefs button
@@ -87,7 +89,9 @@ class PrefsUITest: AppUITestBase {
                     prefsSheet.buttons["Done"].click()
                     snoozeOpts.click()
                     let snoozeOptionLabels = snoozeOptions.allElementsBoundByIndex.map { $0.title }
-                    XCTAssertEqual(["7:00 pm", "7:30 pm", "8:00 pm", "", "tomorrow at 11:23 am"], snoozeOptionLabels)
+                    XCTAssertEqual(
+                        ["7:00 pm", "7:30 pm", "8:00 pm", "", "tomorrow at 11:23 am", "", "Skip this session"],
+                        snoozeOptionLabels)
                 }
                 group("Open preferences back up") {
                     prefsButton.click() // once to dismiss the snooze options popup

--- a/whatdidUITests/app/PtnViewControllerTest.swift
+++ b/whatdidUITests/app/PtnViewControllerTest.swift
@@ -321,4 +321,26 @@ class PtnViewControllerTest: AppUITestBase {
             XCTAssertEqual("", ptn.tcombo.textField.stringValue) // changing pcombo should change tcombo
         }
     }
+
+    func testSkipSessionButton() {
+        group("Fast forward") {
+            setTimeUtc(h: 1, m: 00)
+            waitForTransition(of: .ptn, toIsVisible: true)
+        }
+        group("Skip a session") {
+            find(.ptn).buttons["Skip session"].click()
+            waitForTransition(of: .ptn, toIsVisible: false)
+        }
+        group("Make an entry") {
+            setTimeUtc(h: 1, m: 15)
+            findPtn().pcombo.textField.deleteText(andReplaceWith: "One\tTwo\tThree\r")
+        }
+        group("Validate") {
+            clickStatusMenu()
+            waitForTransition(of: .ptn, toIsVisible: true)
+            XCTAssertEqual(
+                [FlatEntry(from: date(h: 1, m: 00), to: date(h: 1, m: 15), project: "One", task: "Two", notes: "Three")],
+                entriesHook)
+        }
+    }
 }

--- a/whatdidUITests/app/PtnViewControllerTest.swift
+++ b/whatdidUITests/app/PtnViewControllerTest.swift
@@ -323,24 +323,62 @@ class PtnViewControllerTest: AppUITestBase {
     }
 
     func testSkipSessionButton() {
-        group("Fast forward") {
+        func pressSkipSessionButton(warningIncludes: String) -> XCUIElement {
+            let ptn = find(.ptn)
+            group("click skip-session") {
+                let snoozeOptsButton = ptn.menuButtons["snoozeopts"] // note: menuButtons != buttons!
+                snoozeOptsButton.click()
+                let skipOption = snoozeOptsButton.menuItems["Skip this session"]
+                wait(for: "snooze options", until: {skipOption.exists})
+                skipOption.click()
+            }
+            return group("wait for sheet") {() -> XCUIElement in
+                wait(for: "PTN sheet", until: {ptn.sheets.count > 0})
+                let sheet = ptn.sheets.element(boundBy: 0)
+                XCTAssertTrue(
+                    sheet.staticTexts.allElementsBoundByIndex.contains(where: {$0.stringValue.contains(warningIncludes)}))
+                return sheet
+            }
+        }
+        
+        group("Fast forward one hour") {
             setTimeUtc(h: 1, m: 00)
             waitForTransition(of: .ptn, toIsVisible: true)
+            XCTAssertEqual(
+                "What have you been working on for the last 1h 0m (since 2:00 am)?",
+                find(.ptn).staticTexts["durationheader"].stringValue)
         }
-        group("Skip a session") {
-            find(.ptn).buttons["Skip session"].click()
+        
+        group("Skip a session, cancel via escape") {
+            let sheet = pressSkipSessionButton(warningIncludes: "1h 0m")
+            sheet.typeKey(.escape)
+            wait(for: "sheet to go away", until: {!sheet.isVisible})
+            sleepMillis(1000) // give the PTN a chance to go away if it's going to (it shouldn't)
+            XCTAssertEqual(
+                "What have you been working on for the last 1h 0m (since 2:00 am)?",
+                find(.ptn).staticTexts["durationheader"].stringValue)
+        }
+        group("Skip a session, cancel via button") {
+            let sheet = pressSkipSessionButton(warningIncludes: "1h 0m")
+            sheet.buttons["Don't skip"].click()
+            wait(for: "sheet to go away", until: {!sheet.isVisible})
+            sleepMillis(1000) // give the PTN a chance to go away if it's going to (it shouldn't)
+            XCTAssertEqual(
+                "What have you been working on for the last 1h 0m (since 2:00 am)?",
+                find(.ptn).staticTexts["durationheader"].stringValue)
+        }
+        group("Skip a session, confirm skip") {
+            let sheet = pressSkipSessionButton(warningIncludes: "1h 0m")
+            sheet.buttons["Skip session"].click()
+            wait(for: "sheet to go away", until: {!sheet.isVisible})
             waitForTransition(of: .ptn, toIsVisible: false)
         }
-        group("Make an entry") {
-            setTimeUtc(h: 1, m: 15)
-            findPtn().pcombo.textField.deleteText(andReplaceWith: "One\tTwo\tThree\r")
-        }
-        group("Validate") {
+        group("Reopen PTN and confirm new duration") {
             clickStatusMenu()
-            waitForTransition(of: .ptn, toIsVisible: true)
+            let ptn = wait(for: .ptn)
             XCTAssertEqual(
-                [FlatEntry(from: date(h: 1, m: 00), to: date(h: 1, m: 15), project: "One", task: "Two", notes: "Three")],
-                entriesHook)
+                "What have you been working on for the last 0m (since 3:00 am)?",
+                ptn.staticTexts["durationheader"].stringValue)
         }
     }
 }

--- a/whatdidUITests/app/PtnViewControllerTest.swift
+++ b/whatdidUITests/app/PtnViewControllerTest.swift
@@ -358,6 +358,32 @@ class PtnViewControllerTest: AppUITestBase {
                 "What have you been working on for the last 1h 0m (since 2:00 am)?",
                 find(.ptn).staticTexts["durationheader"].stringValue)
         }
+        
+        group("optional: Skip a session, cancel via keyboard") {
+            let sheet = pressSkipSessionButton(warningIncludes: "1h 0m")
+            let focusedElements = sheet.descendants(matching: .any)
+                .matching(NSPredicate(format: "hasKeyboardFocus = true"))
+                .allElementsBoundByIndex
+            if focusedElements.isEmpty {
+                log("No focused descendant. Keyboard navigation isn't set up on this system.")
+                sheet.typeKey(.escape)
+                wait(for: "sheet to go away", until: {!sheet.isVisible})
+                // Don't need to test more; we tested above.
+            } else {
+                XCTAssertEqual("Don't skip", sheet.focusedDescendant.title)
+                sheet.typeKey(.tab)
+                wait(for: "focus to switch 1", until: {sheet.focusedDescendant.title == "Skip session"})
+                sheet.typeKey(.tab)
+                wait(for: "focus to switch 2", until: {sheet.focusedDescendant.title == "Don't skip"})
+                sheet.typeKey(.space)
+                wait(for: "sheet to go away", until: {!sheet.isVisible})
+                sleepMillis(1000) // give the PTN a chance to go away if it's going to (it shouldn't)
+                XCTAssertEqual(
+                    "What have you been working on for the last 1h 0m (since 2:00 am)?",
+                    find(.ptn).staticTexts["durationheader"].stringValue)
+            }
+        }
+        
         group("Skip a session, cancel via button") {
             let sheet = pressSkipSessionButton(warningIncludes: "1h 0m")
             sheet.buttons["Don't skip"].click()

--- a/whatdidUITests/app/ScheduleTest.swift
+++ b/whatdidUITests/app/ScheduleTest.swift
@@ -92,7 +92,9 @@ class ScheduleTest: AppUITestBase {
             // The default option is 7:30 pm, and the extra options start at 8:00 pm.
             let snoozeOptions = openSnoozeOptions(on: ptn)
             let snoozeOptionLabels = snoozeOptions.allElementsBoundByIndex.map { $0.title }
-            XCTAssertEqual(["3:30 am", "4:00 am", "4:30 am", "", "9:00 am"], snoozeOptionLabels)
+            XCTAssertEqual(
+                ["3:30 am", "4:00 am", "4:30 am", "", "9:00 am", "", "Skip this session"],
+                snoozeOptionLabels)
         }
         group("Check weekend snooze-until-tomorrow option") {
             // Jan 1 1970 was a Thursday, so let's go to Friday. Then, the "tomorrow" state
@@ -107,7 +109,9 @@ class ScheduleTest: AppUITestBase {
             group("Check options") {
                 let snoozeOptions = openSnoozeOptions(on: ptn)
                 let snoozeOptionLabels = snoozeOptions.allElementsBoundByIndex.map { $0.title }
-                XCTAssertEqual(["9:00 pm", "9:30 pm", "10:00 pm", "", "Monday at 9:00 am"], snoozeOptionLabels)
+                XCTAssertEqual(
+                    ["9:00 pm", "9:30 pm", "10:00 pm", "", "Monday at 9:00 am", "", "Skip this session"],
+                    snoozeOptionLabels)
             }
             group("Snooze until Monday") {
                 ptn.menuItems["Monday at 9:00 am"].click()

--- a/whatdidUITests/app/ScheduleTest.swift
+++ b/whatdidUITests/app/ScheduleTest.swift
@@ -148,7 +148,7 @@ class ScheduleTest: AppUITestBase {
         let (ptn, _) = openPtnAndGetButton()
         let snoozeOptions = openSnoozeOptions(on: ptn)
         let snoozeOptionLabels = snoozeOptions.allElementsBoundByIndex.map { $0.title }
-        XCTAssertEqual(["3:00 am", "3:30 am", "4:00 am", "", "9:00 am"], snoozeOptionLabels)
+        XCTAssertEqual(["3:00 am", "3:30 am", "4:00 am", "", "9:00 am", "", "Skip this session"], snoozeOptionLabels)
         ptn.menuItems["4:00 am"].click()
         
         // To go 03:29+0200, and the PTN should still be hidden


### PR DESCRIPTION
This has a few components (not all of which are currently done):

- [x] Refactor and tweak the snoozeoptions so that the "now +##" options
      are set in a more targeted manner. The "snooze until tomorrow"
      option won't be caught in that loop; it's set separately.
- [x] Add a new option, which will be "ignore current session." Add a
      UI test for this.
- [x] Warn the user (and maybe force an answer?) if they dismiss the
      long-session prompt by closing the window via the status menu
      item. That will resolve #201.
