### PR TITLE
fix autocomplete scroll bars

### DIFF
--- a/whatdid/controllers/DayEndReportController.swift
+++ b/whatdid/controllers/DayEndReportController.swift
@@ -57,13 +57,8 @@ class DayEndReportController: NSViewController {
     
     override func viewWillAppear() {
         if let scroller = projectsScroll.verticalScroller {
-            scrollBarHelper = ScrollBarHelper(on: scroller) {shows in
-                if shows {
-                    let width = NSScroller.scrollerWidth(for: scroller.controlSize, scrollerStyle: scroller.scrollerStyle)
-                    self.projectsWidthConstraint.constant = width
-                } else {
-                    self.projectsWidthConstraint.constant = 0
-                }
+            scrollBarHelper = ScrollBarHelper(on: scroller) {
+                self.projectsWidthConstraint.constant = $0
             }
         }
         

--- a/whatdid/controllers/DayEndReportController.xib
+++ b/whatdid/controllers/DayEndReportController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
         <capability name="System colors introduced in macOS 10.13" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/whatdid/main/AutoCompletingField.swift
+++ b/whatdid/main/AutoCompletingField.swift
@@ -335,11 +335,14 @@ fileprivate class PopupManager: NSObject, NSWindowDelegate {
     static let HEIGHT_FROM_BOTTOM_OF_FIELD: CGFloat = 2
     static let GROUPING_LABEL_TAG = 1
     private var activeEventMonitors = [Any?]()
+    private var scrollBarHelper: ScrollBarHelper?
     private let optionsPopup: NSPanel
     private let parent: AutoCompletingField
+    private var docViewHorizontalConstraint: NSLayoutConstraint!
     private var matchedSectionSeparators = [NSView]()
     private let mainStack: NSStackView
     private var setWidth: ((CGFloat) -> Void)!
+    private var declaredWidth: CGFloat = 100 // any ol' number will do; we'll set this in show()
     var scrollView: NSScrollView!
     
     init(parent: AutoCompletingField) {
@@ -383,11 +386,22 @@ fileprivate class PopupManager: NSObject, NSWindowDelegate {
         // Also create a constraint for the width, which we'll set as we open the popup.
         scroll.contentView.heightAnchor.constraint(lessThanOrEqualTo: mainStack.heightAnchor).isActive = true
         scroll.heightAnchor.constraint(lessThanOrEqualToConstant: 150).isActive = true
-        let widthConstraint = scroll.contentView.widthAnchor.constraint(equalToConstant: 100) // any ol' value will do
-        widthConstraint.isActive = true
-        setWidth = { widthConstraint.constant = $0 } // ha, a mutable constant!
+        docViewHorizontalConstraint = mainStack.widthAnchor.constraint(equalToConstant: declaredWidth)
+        docViewHorizontalConstraint.isActive = true
+        docViewHorizontalConstraint.priority = .required
+        docViewHorizontalConstraint.identifier = "DOC WIDTH"
+        
+        let scrollWidthConstraint = scroll.widthAnchor.constraint(equalToConstant: declaredWidth)
+        scrollWidthConstraint.isActive = true
+        scrollWidthConstraint.priority = .required
+        scrollWidthConstraint.identifier = "SCROLL WIDTH"
+        
+        setWidth = {
+            scrollWidthConstraint.constant = $0
+            self.declaredWidth = $0
+            self.docViewHorizontalConstraint.constant = $0
+        }
 
-        scroll.contentView.widthAnchor.constraint(lessThanOrEqualTo: mainStack.widthAnchor).isActive = true
         optionsPopup.contentView = scroll
         optionsPopup.level = .popUpMenu
         optionsPopup.setAccessibilityChildren(nil)
@@ -572,6 +586,7 @@ fileprivate class PopupManager: NSObject, NSWindowDelegate {
         guard !windowIsVisible else {
             return
         }
+        setUpScrollBarHelpers()
         setWidth(minWidth)
         var popupOrigin = atTopLeft
         popupOrigin.y -= (optionsPopup.frame.height + PopupManager.HEIGHT_FROM_BOTTOM_OF_FIELD)
@@ -592,7 +607,16 @@ fileprivate class PopupManager: NSObject, NSWindowDelegate {
             })
     }
     
+    private func setUpScrollBarHelpers() {
+        if let scroller = scrollView.verticalScroller {
+            scrollBarHelper = ScrollBarHelper(on: scroller) {
+                self.docViewHorizontalConstraint.constant = self.declaredWidth - $0
+            }
+        }
+    }
+    
     func windowWillClose(_ notification: Notification) {
+        scrollBarHelper = nil
         optionFields.forEach { $0.isSelected = false }
         activeEventMonitors.compactMap{$0}.forEach { NSEvent.removeMonitor($0) }
         activeEventMonitors.removeAll()

--- a/whatdid/util/ScrollBarHelper.swift
+++ b/whatdid/util/ScrollBarHelper.swift
@@ -17,15 +17,23 @@ class ScrollBarHelper {
     ///
     /// This init also registers a notification listener that will only be removed at deinit, so make sure to remove your reference
     /// to this instance when you're done with it.
-    init(on scroller: NSScroller, handler: @escaping (Bool) -> Void) {
+    init(on scroller: NSScroller, handler: @escaping (CGFloat) -> Void) {
+        func onOffHandler(_ isShown: Bool) {
+            if isShown {
+                let width = NSScroller.scrollerWidth(for: scroller.controlSize, scrollerStyle: scroller.scrollerStyle)
+                handler(width)
+            } else {
+                handler(0)
+            }
+        }
         observationRef = scroller.observe(
             \NSScroller.isHidden,
-            changeHandler: {scroller, _ in ScrollBarHelper.handle(on: scroller, handler) })
+            changeHandler: {scroller, _ in ScrollBarHelper.handle(on: scroller, onOffHandler) })
         notificationRef = NotificationCenter.default.addObserver(
             forName: NSScroller.preferredScrollerStyleDidChangeNotification,
             object: nil,
             queue: OperationQueue.main,
-            using: {_ in ScrollBarHelper.handle(on: scroller, handler)})
+            using: {_ in ScrollBarHelper.handle(on: scroller, onOffHandler)})
     }
     
     private static func handle(on scroller: NSScroller, _ handler: @escaping (Bool) -> Void) {


### PR DESCRIPTION
- resize the autocomplete pane such that it doesn't ever show the horizontal scroller
- have long items wrap, rather than being long lines
- when they do wrap, draw a little "racing stripe" to make it more visually obvious

Fixes #221