### PR TITLE
improve custom date picker

### DIFF
--- a/whatdid/controllers/DayEndReportController.xib
+++ b/whatdid/controllers/DayEndReportController.xib
@@ -9,7 +9,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="DayEndReportController" customModule="whatdid" customModuleProvider="target">
             <connections>
-                <outlet property="dateRangePicker" destination="4il-8J-dck" id="Fix-zI-Yx4"/>
+                <outlet property="dateRangePicker" destination="L2g-sp-iaD" id="r4E-nO-QlX"/>
                 <outlet property="goalsSummaryGroup" destination="V55-nV-Y5s" id="DxF-mT-cMT"/>
                 <outlet property="goalsSummaryStack" destination="1RQ-eW-vGH" id="L7V-FB-jCR"/>
                 <outlet property="maxViewHeight" destination="1ka-g6-16p" id="IdU-SA-mes"/>
@@ -27,7 +27,7 @@
             <rect key="frame" x="0.0" y="0.0" width="400" height="99"/>
             <subviews>
                 <stackView identifier="header-h" distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="500" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pKe-k9-zAn" userLabel="Header Stack">
-                    <rect key="frame" x="0.0" y="79" width="218" height="20"/>
+                    <rect key="frame" x="0.0" y="79" width="141" height="20"/>
                     <subviews>
                         <textField identifier="header_label" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wxD-Lm-qUL" userLabel="Header">
                             <rect key="frame" x="-2" y="0.0" width="114" height="16"/>
@@ -37,12 +37,14 @@
                                 <color key="backgroundColor" name="findHighlightColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
-                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="4il-8J-dck" customClass="DateRangePicker" customModule="whatdid" customModuleProvider="target">
-                            <rect key="frame" x="118" y="0.0" width="100" height="16"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="16" placeholder="YES" id="XKx-Xi-Ukw"/>
-                            </constraints>
-                        </customView>
+                        <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="L2g-sp-iaD" customClass="DateRangePicker" customModule="whatdid" customModuleProvider="target">
+                            <rect key="frame" x="118" y="-1" width="23" height="19"/>
+                            <popUpButtonCell key="cell" type="roundRect" bezelStyle="roundedRect" alignment="left" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="djs-mP-Xas">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="cellTitle"/>
+                                <menu key="menu" id="I7d-9W-teY"/>
+                            </popUpButtonCell>
+                        </popUpButton>
                     </subviews>
                     <edgeInsets key="edgeInsets" left="0.0" right="0.0" top="4" bottom="0.0"/>
                     <visibilityPriorities>

--- a/whatdid/views/DateRangePicker.swift
+++ b/whatdid/views/DateRangePicker.swift
@@ -3,18 +3,24 @@
 import Cocoa
 
 @IBDesignable
-class DateRangePicker: NSView {
+class DateRangePicker: NSPopUpButton, NSPopoverDelegate {
     
     private static let MODE_ONE_DAY = "single day"
     private static let MODE_RANGE = "date range"
     
-    private let topStack = NSStackView(orientation: .horizontal)
-    private let modePicker = NSPopUpButton()
+    
     private let dateRangePane = DateRangePane()
+    private var customDateRange: (Date, Date)?
     private let popover = NSPopover()
     private var handlers = [(from: Date, to: Date, because: UpdateReason) -> Void]()
+    private var currentTitle = Title.yesterday
     private var thisMorning: Date = Prefs.dayStartTime.map {hh, mm in
         TimeUtil.dateForTime(.previous, hh: hh, mm: mm)
+    }
+    
+    override init(frame buttonFrame: NSRect, pullsDown flag: Bool) {
+        super.init(frame: buttonFrame, pullsDown: flag)
+        doInit()
     }
     
     override init(frame frameRect: NSRect) {
@@ -28,33 +34,29 @@ class DateRangePicker: NSView {
     }
     
     private func doInit() {
-        addSubview(topStack)
-        topStack.anchorAllSides(to: self)
-        
-        let notifyingCell = NotifyingNSPopUpButtonCell()
-        modePicker.cell = notifyingCell
-        modePicker.addItems(withTitles: ["today", "yesterday", "custom"])
-        notifyingCell.handler = {cell in
-            while cell.numberOfItems > 3 {
-                cell.selectItem(at: 2)
-                cell.removeItem(at: 3)
-            }
+        addItems(withTitles: ["today", "yesterday", "custom"])
+        currentTitle = .today
+        if let cell = cell as? NSPopUpButtonCell {
+            cell.arrowPosition = .noArrow
+            cell.usesItemFromMenu = false
+            cell.menuItem = NSMenuItem(title: itemTitles[0], action: nil, keyEquivalent: "")
+        } else {
+            wdlog(.warn, "modePicker's cell was not NSPopUpButtonCell")
         }
-        notifyingCell.arrowPosition = .noArrow
-        modePicker.bezelStyle = .roundRect // roundRect, textureRounded
-        modePicker.focusRingType = .none
+        bezelStyle = .roundRect // roundRect, textureRounded
+        focusRingType = .none
         
-        modePicker.target = self
-        modePicker.action = #selector(self.changeMode(_:))
+        target = self
+        action = #selector(self.changeMode(_:))
         
         popover.contentViewController = NonFocusingNSViewController()
         popover.contentViewController?.view = dateRangePane
         popover.behavior = .semitransient
+        popover.delegate = self
         dateRangePane.onChange = {_, _ in
             self.notifyHandlers(because: .userAction)
         }
         
-        topStack.addArrangedSubview(modePicker)
         onDateSelection(self.updateMenuItemsFor(start:end:because:))
         prepareToShow()
     }
@@ -65,14 +67,11 @@ class DateRangePicker: NSView {
         invalidateIntrinsicContentSize()
     }
     
-    override func setAccessibilityIdentifier(_ accessibilityIdentifier: String?) {
-        modePicker.setAccessibilityIdentifier(accessibilityIdentifier)
-    }
-    
     func prepareToShow() {
         thisMorning = Prefs.dayStartTime.map {hh, mm in
             TimeUtil.dateForTime(.previous, hh: hh, mm: mm)
         }
+        dateRangePane.prepareToShow()
         notifyHandlers(because: .prepareToShow)
     }
 
@@ -89,18 +88,25 @@ class DateRangePicker: NSView {
         handler(start, end, .initial)
     }
     
-    private func updateMenuItemsFor(start: Date, end: Date, because reason: UpdateReason) {
+    fileprivate func updateMenuItemsFor(start: Date, end: Date, because reason: UpdateReason) {
         if reason == .initial {
             return
         }
+        let modePickerCell = cell as? NSPopUpButtonCell
         let cal = DefaultScheduler.instance.calendar
         let tomorrowMorning = cal.date(byAdding: .day, value: 1, to: thisMorning)
         let yesterdayMorning = cal.date(byAdding: .day, value: -1, to: thisMorning)
         
         if start == thisMorning && end == tomorrowMorning {
-            modePicker.selectItem(at: 0)
+            selectItem(at: 0)
+            currentTitle = .today
+            customDateRange = nil
+            modePickerCell?.menuItem = selectedItem
         } else if (start == yesterdayMorning && end == thisMorning) {
-            modePicker.selectItem(at: 1)
+            selectItem(at: 1)
+            currentTitle = .yesterday
+            customDateRange = nil
+            modePickerCell?.menuItem = selectedItem
         } else {
             let formatter = DateFormatter()
             formatter.setLocalizedDateFormatFromTemplate("dMMM")
@@ -121,11 +127,18 @@ class DateRangePicker: NSView {
                 let conjunction = (cal.date(byAdding: .day, value: 1, to: start) == lastFullDay) ? "and" : "through"
                 customText = "\(format(start)) \(conjunction) \(format(lastFullDay))"
             }
+            modePickerCell?.menuItem = NSMenuItem(title: customText, action: nil, keyEquivalent: "")
+            currentTitle = .custom(title: customText)
+            selectItem(at: 2)
             
-            self.modePicker.addItem(withTitle: customText)
-            self.modePicker.selectItem(at: 3)
+            // We need to reverse the +1d that happened in startAndEndDates. See that comment for why it happens.
+            // Basically, the problem is that DateRangePane is focused on the actual NSDatePicker options, in which
+            // the end-date is the start of the last selected day. This class (DateRangePicker) uses the end date as the
+            // start of the *next* day (so that the actual range reflects all of today). So, we need to translate back
+            // to that NSDatePicker-based view.
+            customDateRange = (start, DefaultScheduler.instance.calendar.date(byAdding: .day, value: -1, to: end)!)
         }
-        self.popover.close()
+        popover.close()
     }
     
     @objc private func changeMode(_ sender: NSPopUpButton) {
@@ -133,17 +146,56 @@ class DateRangePicker: NSView {
         if selected == "today" {
             dateRangePane.dateRange = (thisMorning, thisMorning)
             notifyHandlers(because: .userAction)
+            currentTitle = .today
         } else if (selected == "yesterday") {
             let yesterday = DefaultScheduler.instance.calendar.date(byAdding: .day, value: -1, to: thisMorning)!
             dateRangePane.dateRange = (yesterday, yesterday)
             notifyHandlers(because: .userAction)
-        }
-        if selected == "custom" {
+            currentTitle = .yesterday
+        } else {
             popover.contentViewController?.view.layoutSubtreeIfNeeded()
             popover.contentSize = dateRangePane.intrinsicContentSize
             dateRangePane.prepareToShow()
+            if let initialDateRange = customDateRange {
+                dateRangePane.dateRange = initialDateRange
+            }
+            let modePickerCell = cell as? NSPopUpButtonCell
+            modePickerCell?.menuItem = NSMenuItem(title: "custom", action: nil, keyEquivalent: "")
             popover.show(relativeTo: NSRect.zero, of: sender, preferredEdge: .maxX)
         }
+    }
+    
+    func popoverDidClose(_ notification: Notification) {
+        // This could happen for one of two reasons: either the user selected a custom date, or they clicked outside the
+        // popover (and thus dismissed it). In the latter case, we want to restore the old state, and specifically the selected
+        // item.
+        // For example, let's say the item is currently on "today". I click on the button to show the popdown menu, and then
+        // click "custom" -- that's now the selected item. The popover shows, but I click away to dismiss it. The picker should
+        // still be set to "today", and the button title will show that (since it didn't get any update notification), but the
+        // selected item will still say "custom". We need to change it back.
+        // Note that this means that when we pick a custom date, we actually set the button and menu item twice: once as part
+        // of setting it, and then once again when the popover closes. I'm not too worried about that small amount of inefficiency.
+        let newTitle: String
+        let newIndex: Int
+        switch currentTitle {
+        case .today:
+            newIndex = 0
+            newTitle = "today"
+        case .yesterday:
+            newIndex = 1
+            newTitle = "yesterday"
+        case .custom(title: let title):
+            newIndex = 2
+            newTitle = title
+        }
+        selectItem(at: newIndex)
+        let modePickerCell = cell as? NSPopUpButtonCell
+        modePickerCell?.menuItem = NSMenuItem(title: newTitle, action: nil, keyEquivalent: "")
+    }
+    
+    override func accessibilityValue() -> Any? {
+        let cell = cell as? NSPopUpButtonCell
+        return cell?.menuItem?.title
     }
     
     private func notifyHandlers(because reason: UpdateReason) {
@@ -172,14 +224,10 @@ class DateRangePicker: NSView {
         notifyHandlers(because: .userAction)
     }
     
-    private class NotifyingNSPopUpButtonCell: NSPopUpButtonCell {
-        
-        fileprivate var handler: ((NSPopUpButtonCell) -> Void) = {_ in }
-        
-        override func attachPopUp(withFrame cellFrame: NSRect, in controlView: NSView) {
-            handler(self)
-            super.attachPopUp(withFrame: cellFrame, in: controlView)
-        }
+    private enum Title {
+        case yesterday
+        case today
+        case custom(title: String)
     }
 }
 


### PR DESCRIPTION
If you have a custom date and then select to pick a new one, it'll
default to the current one. Also various cases for when you click away
to dismiss the custom-date selector without picking a new custom date.

This fixes #240.