### PR TITLE
UI tweaks

### DIFF
--- a/whatdid/controllers/DayEndReportController.xib
+++ b/whatdid/controllers/DayEndReportController.xib
@@ -27,7 +27,7 @@
             <rect key="frame" x="0.0" y="0.0" width="400" height="103"/>
             <subviews>
                 <stackView identifier="header-h" distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="500" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pKe-k9-zAn" userLabel="Header Stack">
-                    <rect key="frame" x="0.0" y="79" width="187" height="22"/>
+                    <rect key="frame" x="0.0" y="79" width="299" height="22"/>
                     <subviews>
                         <textField identifier="header_label" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wxD-Lm-qUL" userLabel="Header">
                             <rect key="frame" x="-2" y="2" width="114" height="16"/>
@@ -49,8 +49,8 @@
                             <rect key="frame" x="147" y="0.0" width="5" height="18"/>
                         </box>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Tzb-6g-cBT">
-                            <rect key="frame" x="158" y="-1" width="29" height="19"/>
-                            <buttonCell key="cell" type="roundRect" title="Open in new window" bezelStyle="roundedRect" image="macwindow.on.rectangle" catalog="system" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Uuc-mI-XyP">
+                            <rect key="frame" x="158" y="-1" width="141" height="19"/>
+                            <buttonCell key="cell" type="roundRect" title="open in new window ➚" bezelStyle="roundedRect" image="macwindow.on.rectangle" catalog="system" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Uuc-mI-XyP">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="cellTitle"/>
                             </buttonCell>

--- a/whatdid/controllers/LargeReportController.swift
+++ b/whatdid/controllers/LargeReportController.swift
@@ -52,7 +52,7 @@ class LargeReportController: NSWindowController, NSWindowDelegate, NSOutlineView
             createSpinner.setContentHuggingPriority(.defaultLow, for: .horizontal)
             createSpinner.setContentHuggingPriority(.defaultLow, for: .vertical)
             createSpinner.widthAnchor.constraint(equalTo: tasksTreeView.widthAnchor).isActive = true
-            createSpinner.leadingAnchor.constraint(equalTo: tasksTreeView.leadingAnchor).isActive = true
+            createSpinner.centerXAnchor.constraint(equalTo: tasksTreeView.centerXAnchor).isActive = true
             createSpinner.centerYAnchor.constraint(equalTo: tasksTreeView.centerYAnchor).isActive = true
             if #available(macOS 11.0, *) {
                 createSpinner.controlSize = .large

--- a/whatdid/controllers/LargeReportController.xib
+++ b/whatdid/controllers/LargeReportController.xib
@@ -26,13 +26,13 @@
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZIY-aJ-KRQ" userLabel="Main VStack">
-                        <rect key="frame" x="0.0" y="0.0" width="720" height="298"/>
+                        <rect key="frame" x="0.0" y="0.0" width="720" height="300"/>
                         <subviews>
                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalHuggingPriority="900" verticalHuggingPriority="900" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NO3-hW-ZX5" userLabel="Header stack">
-                                <rect key="frame" x="4" y="276" width="363" height="18"/>
+                                <rect key="frame" x="4" y="276" width="388" height="20"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lQa-tq-gAO">
-                                        <rect key="frame" x="-2" y="1" width="94" height="16"/>
+                                        <rect key="frame" x="-2" y="2" width="94" height="16"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" title="Show tasks for" id="Lff-dS-BDd">
                                             <font key="font" usesAppearanceFont="YES"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -40,18 +40,18 @@
                                         </textFieldCell>
                                     </textField>
                                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bof-8N-kbY" customClass="DateRangePicker" customModule="whatdid" customModuleProvider="target">
-                                        <rect key="frame" x="98" y="-1" width="23" height="19"/>
-                                        <popUpButtonCell key="cell" type="roundRect" bezelStyle="roundedRect" alignment="left" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3KH-rR-swx">
+                                        <rect key="frame" x="95" y="-4" width="39" height="25"/>
+                                        <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="center" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3KH-rR-swx">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="cellTitle"/>
+                                            <font key="font" metaFont="system"/>
                                             <menu key="menu" id="jrf-Hr-Aoh"/>
                                         </popUpButtonCell>
                                     </popUpButton>
                                     <box horizontalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="u7S-59-AVB">
-                                        <rect key="frame" x="127" y="0.0" width="5" height="18"/>
+                                        <rect key="frame" x="136" y="0.0" width="5" height="20"/>
                                     </box>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jWh-Rz-339">
-                                        <rect key="frame" x="136" y="2" width="142" height="14"/>
+                                        <rect key="frame" x="145" y="3" width="142" height="14"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" title="Sort projects and tasks by" id="Wcn-dG-f9B">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -59,10 +59,10 @@
                                         </textFieldCell>
                                     </textField>
                                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="N0L-ii-cQW">
-                                        <rect key="frame" x="280" y="-3" width="87" height="22"/>
-                                        <popUpButtonCell key="cell" type="push" title="Most time" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="9P5-og-VJW" id="RpY-qq-fJs">
-                                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="smallSystem"/>
+                                        <rect key="frame" x="290" y="-4" width="102" height="25"/>
+                                        <popUpButtonCell key="cell" type="push" title="Most time" bezelStyle="rounded" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="9P5-og-VJW" id="RpY-qq-fJs">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
                                             <menu key="menu" id="eCK-at-OSS">
                                                 <items>
                                                     <menuItem title="Most time" state="on" id="9P5-og-VJW"/>

--- a/whatdid/main/MainMenu.swift
+++ b/whatdid/main/MainMenu.swift
@@ -159,7 +159,9 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate, PtnViewDel
                 stack.setHuggingPriority(.defaultHigh, for: .horizontal)
                 stack.edgeInsets = NSEdgeInsets(top: 10, left: 15, bottom: 10, right: 15)
                 startupMessages.forEach {
-                    stack.addArrangedSubview(NSTextField(labelWithString: $0.humanReadable))
+                    let msg = NSTextField(labelWithString: $0.humanReadable)
+                    msg.drawsBackground = false
+                    stack.addArrangedSubview(msg)
                 }
                 stack.wantsLayer = true
                 stack.layer?.backgroundColor = NSColor.yellow.cgColor

--- a/whatdid/views/DateRangePicker.swift
+++ b/whatdid/views/DateRangePicker.swift
@@ -42,7 +42,6 @@ class DateRangePicker: NSPopUpButton, NSPopoverDelegate {
         } else {
             wdlog(.warn, "modePicker's cell was not NSPopUpButtonCell")
         }
-        bezelStyle = .roundRect // roundRect, textureRounded
         focusRingType = .none
         
         target = self


### PR DESCRIPTION
- date-range picker can now change style
- "open in new window" button doesn't use fancy icon (it's not available
  on older macs)
- maybe fix the slightly ugly background for the "updated" message?
- Make the spinner centered, instead of having it take the full width.
  I originally had it full-width because it would turn into a bar for
  the determinate phase, but it doesn't do that anymore. On older macOS
  versions, the pie spinner left-aligns within its box, so making it be
  full-width makes it appear on the left.