### PR TITLE
Fix dangling popup

### DIFF
--- a/whatdid/ui_testhook/WhatdidControlHooks.swift
+++ b/whatdid/ui_testhook/WhatdidControlHooks.swift
@@ -215,7 +215,25 @@ class WhatdidControlHooks: NSObject, NSTextFieldDelegate {
     }
     
     func controlTextDidEndEditing(_ obj: Notification) {
-        updateDate()
+        if NSApp.currentEvent?.modifierFlags.contains(.shift) ?? false {
+            let origValue = setter.stringValue
+            setter.isEnabled = false
+            var secondsRemaining = 3
+            Timer.scheduledTimer(withTimeInterval: TimeInterval(1), repeats: true, block: {timer in
+                if secondsRemaining == 0 {
+                    timer.invalidate()
+                    self.setter.isEnabled = true
+                    self.setter.stringValue = origValue
+                    self.updateDate()
+                } else {
+                    self.setter.stringValue = "Setting in \(secondsRemaining)..."
+                    secondsRemaining -= 1
+                }
+            }).fire()
+        }
+        if setter.isEnabled {
+            updateDate()
+        }
     }
     
     func updateDateDisplays(to date: Date) {

--- a/whatdid/views/TextFieldWithPopup.swift
+++ b/whatdid/views/TextFieldWithPopup.swift
@@ -263,6 +263,9 @@ class TextFieldWithPopup: WhatdidTextField, NSTextViewDelegate, NSTextFieldDeleg
     }
     
     func showOptions() {
+        if window?.attachedSheet != nil {
+            return
+        }
         let originWithinWindow = superview!.convert(frame.origin, to: nil)
         let originWithinScreen = window!.convertPoint(toScreen: originWithinWindow)
         popupManager.show(


### PR DESCRIPTION
If a sheet opens up over the popup, and then someone asks the autoresponder to become the first responder (as PTN does, within the `grabFocusNow()` it calls on open), the popup pops through the sheet. This looks really bad. So, fix it.

Manual tests:

* PTN opens with a sheet
    1. start up whatdid in UI test mode
    2. set the time to 60000
    3. PTN will open with a "it's been a while" sheet; confirm no popup
* PTN is already open
    1. start up whatdid in UI test mode
    2. open up the PTN
    3. set the time to 60000, but using the delayed timer (hold ⇧shift while pressing enter)
    4. before the timer expires, open one of the autocomplete popups
    5. it should close when the PTN opens