### PR TITLE
fix autocomplete scroll bars

### DIFF
--- a/whatdid/views/TextFieldWithPopup.swift
+++ b/whatdid/views/TextFieldWithPopup.swift
@@ -415,7 +415,7 @@ fileprivate class PopupManager: NSObject, NSWindowDelegate, TextFieldWithPopupCa
             // an event to start the click. If we start the click, ignore the event. If it's the end of the
             // click, we'll handle the select.
             if event.type != .leftMouseUp {
-                return false
+                return true
             }
             
             if let contents = contents {


### PR DESCRIPTION
If it's not a leftMouseUp, then return `true` so that we let the rest of the system handle the event. This lets it percolate down to the scroll bars, as it show.

Fixes #222 (as well as a regression introduced by #297, which broke the scroll bar altogether.)