### PR TITLE
explicitly set text color for pull-downs

### DIFF
--- a/whatdid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/whatdid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "KeyboardShortcuts",
-        "repositoryURL": "https://github.com/sindresorhus/KeyboardShortcuts",
-        "state": {
-          "branch": null,
-          "revision": "d97e5e9c62086ffd5fa5fffeadf70b478aa612e2",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "Sparkle",
-        "repositoryURL": "https://github.com/sparkle-project/Sparkle",
-        "state": {
-          "branch": "2.x",
-          "revision": "df313f7f594619d33951bbcae01f6fd5dcb3e91d",
-          "version": null
-        }
+  "pins" : [
+    {
+      "identity" : "keyboardshortcuts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
+      "state" : {
+        "revision" : "f09de800a4f05d66fe2a9924c81a932454a9f39a",
+        "version" : "0.7.1"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "branch" : "2.x",
+        "revision" : "df313f7f594619d33951bbcae01f6fd5dcb3e91d"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/whatdid/views/TextOptionsList.swift
+++ b/whatdid/views/TextOptionsList.swift
@@ -379,9 +379,9 @@ class TextOptionsList: WdView, TextFieldWithPopupContents {
     
     class DisplayTextBuilder {
         private static let labelAttrs: [NSAttributedString.Key : Any] = [
-            .font: NSFont.systemFont(ofSize: NSFont.smallSystemFontSize * 0.9),
-            .foregroundColor: NSColor.systemGray,
-            .underlineColor: NSColor.systemGray,
+            .font: NSFont.systemFont(ofSize: NSFont.smallSystemFontSize),
+            .foregroundColor: NSColor.disabledControlTextColor,
+            .underlineColor: NSColor.disabledControlTextColor,
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
         private static let hrSeparatorAttrs: [NSAttributedString.Key : Any] = [
@@ -406,6 +406,7 @@ class TextOptionsList: WdView, TextFieldWithPopupContents {
         var optionAttrs: [NSAttributedString.Key : Any] {
             return [
                 .font: NSFont.labelFont(ofSize: NSFont.systemFontSize),
+                .foregroundColor: NSColor.textColor,
                 .paragraphStyle: paragraphStyle,
             ]
         }


### PR DESCRIPTION
The main work is just the one line:

    .foregroundColor: NSColor.textColor,

Other work:

- for the section header:
  - use a semantic color rather than just gray
  - make the font size a bit bigger; it was too small
- update dependencies

This fixes #324.