### PR TITLE
create a separate UserDefaults in UI Test mode

### DIFF
--- a/whatdid/main/AppDelegate.swift
+++ b/whatdid/main/AppDelegate.swift
@@ -22,7 +22,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, NSMenuDe
     
     #if UI_TEST
     private var uiTestWindow: UiTestWindow!
-    private var oldPrefs: [String : Any]?
     #endif
     
     var model: Model {
@@ -43,7 +42,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, NSMenuDe
         mainMenu.reset()
         resetModel()
         kickOffInitialSchedules()
-        resetAllPrefs()
+        Prefs.resetRaw()
         globalLogHook.reset()
     }
     #endif
@@ -65,12 +64,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, NSMenuDe
         uiTestWindow = UiTestWindow()
         uiTestWindow.show()
         NSApp.setActivationPolicy(.accessory)
-        if let bundleId = Bundle.main.bundleIdentifier {
-            let bundleId = bundleId + "UI" // isolate it from a release build's prefs on the same machine
-            oldPrefs = UserDefaults.standard.persistentDomain(forName: bundleId)
-            wdlog(.info, "Removing old preferences because this is a UI test. Saved %d to restore later.", oldPrefs?.count ?? 0)
-            UserDefaults.standard.setPersistentDomain([String: Any](), forName: bundleId)
-        }
         #endif
         
         AppDelegate.DEBUG_DATE_FORMATTER.timeZone = DefaultScheduler.instance.timeZone
@@ -117,16 +110,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, NSMenuDe
     
     func applicationWillTerminate(_ notification: Notification) {
         wdlog(.info, "whatdid is shutting down")
-        #if UI_TEST
-        if let bundleId = Bundle.main.bundleIdentifier {
-            if let toRestore = oldPrefs {
-                wdlog(.info, "Restoring old preferences")
-                UserDefaults.standard.setPersistentDomain(toRestore, forName: bundleId)
-            } else {
-                wdlog(.info, "No previous preferences to restore")
-            }
-        }
-        #endif
     }
     
     func windowOpened(_ window: NSWindowController) {

--- a/whatdid/ui_testhook/WhatdidControlHooks.swift
+++ b/whatdid/ui_testhook/WhatdidControlHooks.swift
@@ -49,7 +49,7 @@ class WhatdidControlHooks: NSObject, NSTextFieldDelegate {
         hideStatusItem = NSButton(checkboxWithTitle: "Hide 'Focus Whatdid' Status Item", target: nil, action: nil)
         
         showConstraints = NSButton(checkboxWithTitle: "Show UI constraints", target: nil, action: nil)
-        showConstraints.state = UserDefaults.standard.bool(forKey: WhatdidControlHooks.showUiConstraintsPrefsKey) ? .on : .off
+        showConstraints.state = Prefs.raw.bool(forKey: WhatdidControlHooks.showUiConstraintsPrefsKey) ? .on : .off
         
         super.init()
         
@@ -221,8 +221,8 @@ class WhatdidControlHooks: NSObject, NSTextFieldDelegate {
     
     @objc private func toggleShowUiConstraints(_ toggle: NSButton) {
         let key = WhatdidControlHooks.showUiConstraintsPrefsKey
-        UserDefaults.standard.set(toggle.state == .on, forKey: key)
-        wdlog(.debug, "%@ is now %d", key, UserDefaults.standard.bool(forKey: key))
+        Prefs.raw.set(toggle.state == .on, forKey: key)
+        wdlog(.debug, "%@ is now %d", key, Prefs.raw.bool(forKey: key))
     }
     
     func populateJsonFlatEntryField() {


### PR DESCRIPTION
Rather than trying to clear things out in UI Test mode, just create a different UserDefaults instance for it, and disable persistence on it. That's simpler, and you don't need to worry about not restoring the prefs if you kill the process instead of requesting an orderly shutdown.

fixes #340