### PR TITLE
add a few usage tracker calls

### DIFF
--- a/whatdid.xcodeproj/xcshareddata/xcschemes/whatdid-ui-test.xcscheme
+++ b/whatdid.xcodeproj/xcshareddata/xcschemes/whatdid-ui-test.xcscheme
@@ -74,7 +74,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "SUPPRESS_TUTORIAL"
-            value = "false"
+            value = "true"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/whatdid/controllers/LargeReportController.swift
+++ b/whatdid/controllers/LargeReportController.swift
@@ -28,8 +28,6 @@ class LargeReportController: NSWindowController, NSWindowDelegate {
         editsController.viewDidLoad()
         editsController.model = model
         
-        
-
         // Set up the edits view
 
         // Set up the search bar
@@ -57,6 +55,7 @@ class LargeReportController: NSWindowController, NSWindowDelegate {
         AppDelegate.instance.windowOpened(self)
         super.showWindow(sender)
         dateRangePicker.prepareToShow()
+        UsageTracking.recordAction(.OpenInWindow)
     }
     
     private func setControlsEnabled(_ enabled: Bool) {

--- a/whatdid/controllers/prefs/PrefsViewController.swift
+++ b/whatdid/controllers/prefs/PrefsViewController.swift
@@ -56,6 +56,10 @@ class PrefsViewController: NSViewController {
         tabButtonsStack.addArrangedSubview(NSView()) // trailing spacer
     }
     
+    override func viewDidAppear() {
+        UsageTracking.recordAction(.SettingsPaneOpen)
+    }
+    
     override func viewWillAppear() {
         NSAppearance.withEffectiveAppearance {
             tabButtonsStack.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor

--- a/whatdid/main/AppDelegate.swift
+++ b/whatdid/main/AppDelegate.swift
@@ -14,10 +14,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, NSMenuDe
 
     private var _model = Model() {
         didSet {
-            analytics.setModel(model)
+            UsageTracking.instance.setModel(model)
         }
     }
-    private let analytics = UsageTracking()
     
     @IBOutlet weak var mainMenu: MainMenu!
     private var deactivationHooks : Atomic<[() -> Void]> = Atomic(wrappedValue: [])
@@ -88,8 +87,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, NSMenuDe
     func applicationDidFinishLaunching(_: Notification) {
         wdlog(.info, "Starting whatdid with build %{public}@", Version.pretty)
         // Start tracking analytics (if allowed)
-        analytics.setModel(model)
-        Prefs.$analyticsEnabled.addListener(analytics.setEnabled(_:)) // This also schedules an initial check
+        UsageTracking.instance.setModel(model)
+        Prefs.$analyticsEnabled.addListener(UsageTracking.instance.setEnabled(_:)) // This also schedules an initial check
         
         #if UI_TEST
         wdlog(.info, "initializing UI test hooks")

--- a/whatdid/main/MainMenu.swift
+++ b/whatdid/main/MainMenu.swift
@@ -184,9 +184,14 @@ class MainMenu: NSWindowController, NSWindowDelegate, NSMenuDelegate, PtnViewDel
         if isOpen {
             close()
         } else {
-            let showWhat = NSEvent.modifierFlags.contains(.option)
-                ? WindowContents.dailyEnd
-                : WindowContents.ptn
+            let showWhat: MainMenu.WindowContents
+            if NSEvent.modifierFlags.contains(.option) {
+                showWhat = WindowContents.dailyEnd
+                UsageTracking.recordAction(.ManualReportOpen)
+            } else {
+                showWhat = WindowContents.ptn
+                UsageTracking.recordAction(.ManualOpen)
+            }
             opener.open(showWhat, reason: .manual)
         }
     }

--- a/whatdid/util/Prefs.swift
+++ b/whatdid/util/Prefs.swift
@@ -8,11 +8,11 @@ struct Prefs {
     @Pref(key: "daysIncludeWeekends") static var daysIncludeWeekends = false
     @Pref(key: "ptnFrequencyMinutes") static var ptnFrequencyMinutes = 12
     @Pref(key: "ptnFrequencyJitterMinutes") static var ptnFrequencyJitterMinutes = 2
-    @Pref(key: "launchAtLogin") static var launchAtLogin = true
+    @Pref(key: "launchAtLogin") static var launchAtLogin = false
     @Pref(key: "previouslyLaunchedVersion") static var tutorialVersion = -1
     @Pref(key: "requireNotes") static var requireNotes = false
     @Pref(key: "startupMessages") static var startupMessages = [StartupMessage]()
-    @Pref(key: "analyticsEnabled") static var analyticsEnabled = true
+    @Pref(key: "analyticsEnabled") static var analyticsEnabled = false
     @Pref(key: "analyticsTrackerId") static var trackerId = UUID()
     
     // The following aren't actually prefs, but rather just bits of info persisted across runs.

--- a/whatdid/util/usagetracking/UsageAction.swift
+++ b/whatdid/util/usagetracking/UsageAction.swift
@@ -8,4 +8,7 @@
 
 enum UsageAction: String {
     case ManualOpen;
+    case ManualReportOpen;
+    case SettingsPaneOpen;
+    case OpenInWindow;
 }


### PR DESCRIPTION
Also, disable analytics by default in the prefs. We still "manually"
enable it on first startup, and ask the user if they want it on. But the
failsafe mode is off, if the pref isn't set in that initial workflow for
some reason.

This resolves #349.
